### PR TITLE
Update mfaktc.ini default GPUSieveSize=256

### DIFF
--- a/mfaktc.ini
+++ b/mfaktc.ini
@@ -261,9 +261,9 @@ GPUSievePrimes=82486
 # Minimum: GPUSieveSize=4
 # Maximum: GPUSieveSize=2047
 #
-# Default: GPUSieveSize=2047
+# Default: GPUSieveSize=256
 
-GPUSieveSize=2047
+GPUSieveSize=256
 
 
 # GPUSieveProcessSize defines how far many bits of the sieve each TF block


### PR DESCRIPTION
Suggested from https://www.mersenneforum.org/node/9313?p=1064746#post1064746 to alleviate problems on old GPUs