### PR TITLE
Fix logfile corruption introduced in bc113ef

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -21,6 +21,7 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <stdlib.h>
 #include <math.h>
 #include <cuda_runtime.h>
 #include <time.h>
@@ -68,14 +69,29 @@ void logprintf(mystuff_t* mystuff, const char* fmt, ...)
     va_list args;
 
     va_start(args, fmt);
-    vfprintf(stdout, fmt, args);
+    int len = vfprintf(stdout, fmt, args);
     va_end(args);
 
-    if (mystuff->logging == 1 && mystuff->logfileptr != NULL) {
+    if (mystuff->logging == 1 && mystuff->logfileptr != NULL && len > 0)
+      if (mystuff->printmode == 1) {
+        char* buffer = (char*)malloc(len + 1);
+        va_start(args, fmt);
+        vsnprintf(buffer, len + 1, fmt, args);
+        va_end(args);
+
+        // Replace to CR to LF if it's last char in the string when writing to logfile
+        if (buffer[len - 1] == '\r')
+          buffer[len - 1] = '\n';
+
+        fprintf(mystuff->logfileptr, "%s", buffer);
+        free(buffer);
+      }
+      else
+      {
         va_start(args, fmt);
         vfprintf(mystuff->logfileptr, fmt, args);
         va_end(args);
-    }
+      }
 }
 
 

--- a/src/output.c
+++ b/src/output.c
@@ -69,13 +69,7 @@ void logprintf(mystuff_t* mystuff, const char* fmt, ...)
 
     va_start(args, fmt);
     vfprintf(stdout, fmt, args);
-    _logf(mystuff, fmt, args);
     va_end(args);
-}
-
-void _logf(mystuff_t* mystuff, const char* fmt, ...)
-{
-    va_list args;
 
     if (mystuff->logging == 1 && mystuff->logfileptr != NULL) {
         va_start(args, fmt);
@@ -372,28 +366,16 @@ void print_status_line(mystuff_t *mystuff)
   
   if(mystuff->mode == MODE_NORMAL)
   {
-    if (mystuff->printmode == 1)
-    {
-      buffer[index] = 0;
-      printf("%s\r", buffer);
-      _logf(mystuff, "%s\n", buffer);
-    }
-    else
-    {
-      index += sprintf(buffer + index, "\n");
-      buffer[index] = 0;
-      logprintf(mystuff, "%s", buffer);
-    }
+    if(mystuff->printmode == 1)index += sprintf(buffer + index, "\r");
+    else                       index += sprintf(buffer + index, "\n");
   }
-  else
+  if(mystuff->mode == MODE_SELFTEST_FULL && mystuff->printmode == 0)
   {
-    if (mystuff->mode == MODE_SELFTEST_FULL && mystuff->printmode == 0)
-    {
-      index += sprintf(buffer + index, "\n");
-    }
-    buffer[index] = 0;
-    logprintf(mystuff, "%s", buffer);
+    index += sprintf(buffer + index, "\n");
   }
+
+  buffer[index] = 0;
+  logprintf(mystuff, "%s", buffer);
 }
 
 void get_utc_timestamp(char* timestamp)

--- a/src/output.h
+++ b/src/output.h
@@ -22,7 +22,6 @@ extern "C" {
 #endif
 void print_help(char *string);
 void logprintf(mystuff_t* mystuff, const char* fmt, ...);
-void _logf(mystuff_t* mystuff, const char* fmt, ...);
 
 void print_dez72(int72 a, char *buf);
 void print_dez144(int144 a, char *buf);


### PR DESCRIPTION
This fixes https://github.com/primesearch/mfaktc/issues/9

Initially introduced in the commit https://github.com/primesearch/mfaktc/commit/bc113efb71c07adb140ef05f414b7399416a3c2b, which was trying to pass va_list to a variadic function _logf() directly. This resulted corruption of the integer values printed to log file by passing pointer to a wrong type. Confirmed at least with GCC compiler under Linux.

This PR provides a working fix by formatting a string in buffer first and then replacing '\r' at the end if PrintMode set to 1.

I did not bumped software version, because it causes save file incompatibility while changes affects only logging. But can update PR to apply new version if that's preferred.

Tested with Linux / gcc 11.4.0. Automated binary builds for testing can be obtained from here: https://github.com/N-Storm/mfaktc/releases/tag/0.23.1-logfix-printmode1