### PR TITLE
CI/CD with Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
+# Begin job "build"
   build:
     runs-on: ubuntu-latest
 
@@ -112,8 +113,7 @@ jobs:
           SCRIPT: cd /workspace/src && make -j$(nproc)
         run: docker exec build-container bash -c "$SCRIPT"
 
-      - name: Prepare zip archive for release and build description
-        if: startsWith(github.ref, 'refs/tags')
+      - name: Prepare zip archive with the description
         env:
           SCRIPT: |
             cd /workspace
@@ -123,13 +123,14 @@ jobs:
             ${{ steps.update_makefile.outputs.CCMAX }} | ${{ matrix.sys.ct_os }} | $(gcc --version | head -n1) | $(nvcc --version | tail -n1)" > ${BASE_NAME}.txt
         run: docker exec build-container bash -c "$SCRIPT"
 
-      - name: Upload build artifacts for release
-        if: startsWith(github.ref, 'refs/tags')
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}
           path: mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}.*
+# End job "build"
 
+# Begin job "upload_release"
   upload_release:
     if: startsWith(github.ref, 'refs/tags/')
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: "nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}"
-
-    permissions:
-      contents: write
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
@@ -19,6 +15,8 @@ jobs:
 
       matrix:
         sys:
+          # Specified version combination must exist as CUDA container image from NVidia: nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}
+          # Available versions can be found here: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags (note that only Ubuntus are supported by this action)
           - { cuda_version: '12.8.0', ct_os: 'ubuntu22.04' }
           - { cuda_version: '12.6.3', ct_os: 'ubuntu22.04' }
           - { cuda_version: '12.6.2', ct_os: 'ubuntu22.04' }
@@ -51,63 +49,118 @@ jobs:
           - { cuda_version: '9.2', ct_os: 'ubuntu18.04' }
           - { cuda_version: '8.0', ct_os: 'ubuntu16.04' }
 
+    env:
+      # We can't use GitHub direct container support on old Ubuntu versions, because actions will fail running from these due to old glibc.cancel-timeout-minutes.cancel-timeout-minutes.
+      # As a workaround, Docker containers will be launched separately, running build related actions inside the container via 'docker exec', while generic actions will run on the
+      # host runner VM itself.
+      CONTAINER: "nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}"
+
     steps:
 
-    - name: Fix GPG keys for NVidia repo on Ubuntu 16.04
-      if: matrix.sys.ct_os == 'ubuntu16.04'
-      run: |
-        apt update || /bin/true
-        apt install -y wget
-        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
-        apt-key add 3bf863cc.pub
+      - name: Start Docker Container
+        run: |
+          docker pull $CONTAINER
+          docker run --name build-container -d -v ${{ github.workspace }}:/workspace $CONTAINER tail -f /dev/null
 
-    - name: Update & install required packages inside the container
-      run: |
-        apt update
-        apt -y full-upgrade
-        apt install -y build-essential curl git make python3 sudo unzip wget zip
+      - name: Fix GPG keys for NVidia repo on Ubuntu 16.04
+        if: matrix.sys.ct_os == 'ubuntu16.04'
+        env:
+          SCRIPT: apt-key add /workspace/3bf863cc.pub
+        run: |
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
+          docker exec build-container bash -c "$SCRIPT"
 
-    - name: Checkout repo
-      if: matrix.sys.ct_os == 'ubuntu22.04' || matrix.sys.ct_os == 'ubuntu20.04'
-      uses: actions/checkout@v3
+      - name: Update & install required packages inside the container
+        env:
+          SCRIPT: |
+            apt update
+            apt -y full-upgrade
+            apt install -y build-essential curl git make python3 sudo unzip wget zip
+        run: docker exec build-container bash -c "$SCRIPT"
 
-    - name: Checkout repo
-      if: matrix.sys.ct_os != 'ubuntu22.04' && matrix.sys.ct_os != 'ubuntu20.04'
-      uses: actions/checkout@v1
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-    - name: Update Makefile
-      id: update_makefile
-      shell: bash
-      run: |
-        echo -n "Checking for nvcc maximum supported CC... "
-        export CCMAX=$(nvcc --help | grep -Eoe "compute_[0-9]{2}" | cut -d '_' -f2 | sort -un | tail -n1)
-        echo $CCMAX
-        echo "CCMAX=$CCMAX" >> $GITHUB_OUTPUT
+      - name: Update Makefile
+        id: update_makefile
+        shell: bash
+        env:
+          SCRIPT: |
+            cd /workspace
+            echo -n "Checking for nvcc maximum supported CC... "
+            export CCMAX=$(nvcc --help | grep -Eoe "compute_[0-9]{2}" | cut -d '_' -f2 | sort -un | tail -n1)
+            echo $CCMAX
+            echo "CCMAX=$CCMAX" >> GITHUB_OUTPUT
 
-        echo "Removing unsupported CCs (> $CCMAX) from the Makefile"
-        for cc in $(grep -E '^NVCCFLAGS \+=.*?compute_[0-9]{2}' src/Makefile | grep -Eoe 'compute_[0-9]{2}' | tr -d '\r' | cut -d '_' -f2 | xargs); do
-          if [[ $cc -gt $CCMAX ]]; then
-            echo "Removing CC $cc"
-            sed -i -E "/^NVCCFLAGS \+=.*?compute_$cc/d" src/Makefile
-          fi
-        done
+            echo "Removing unsupported CCs (> $CCMAX) from the Makefile"
+            for cc in $(grep -E '^NVCCFLAGS \+=.*?compute_[0-9]{2}' src/Makefile | grep -Eoe 'compute_[0-9]{2}' | tr -d '\r' | cut -d '_' -f2 | xargs); do
+              if [[ $cc -gt $CCMAX ]]; then
+                echo "Removing CC $cc"
+                sed -i -E "/^NVCCFLAGS \+=.*?compute_$cc/d" src/Makefile
+              fi
+            done
 
-        echo "Adding libraries to LDFLAGS to support static build on older Ubuntu versions..."
-        sed -i -E 's/^(LDFLAGS = .*? -lcudart_static) (.*)/\1 -ldl -lrt -lpthread \2/' src/Makefile
+            echo "Adding libraries to LDFLAGS to support static build on older Ubuntu versions..."
+            sed -i -E 's/^(LDFLAGS = .*? -lcudart_static) (.*)/\1 -ldl -lrt -lpthread \2/' src/Makefile
+        run: |
+          docker exec build-container bash -c "$SCRIPT"
+          cat GITHUB_OUTPUT > $GITHUB_OUTPUT
+          rm -f GITHUB_OUTPUT
 
-    - name: Build from sources
-      run: cd src && make -j$(nproc)
+      - name: Build from sources
+        env:
+          SCRIPT: cd /workspace/src && make -j$(nproc)
+        run: docker exec build-container bash -c "$SCRIPT"
 
-    - name: Prepare zip archive for release
-      if: startsWith(github.ref, 'refs/tags')
-      run: zip -9 -j mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}.zip *
+      - name: Prepare zip archive for release and build description
+        if: startsWith(github.ref, 'refs/tags')
+        env:
+          SCRIPT: |
+            cd /workspace
+            export BASE_NAME="mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}"
+            zip -9 -j ${BASE_NAME}.zip *
+            echo "[${BASE_NAME}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${BASE_NAME}.zip) | \
+            ${{ steps.update_makefile.outputs.CCMAX }} | ${{ matrix.sys.ct_os }} | $(gcc --version | head -n1) | $(nvcc --version | tail -n1)" > ${BASE_NAME}.txt
+        run: docker exec build-container bash -c "$SCRIPT"
 
-    - name: Make and upload release
-      uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags')
-      with:
-        fail_on_unmatched_files: false
-        generate_release_notes: true
-        files: mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}.zip
-        append_body: true
-        body: " - mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}.zip: max CC ${{ steps.update_makefile.outputs.CCMAX }}, build os ${{ matrix.sys.ct_os }}"
+      - name: Upload build artifacts for release
+        if: startsWith(github.ref, 'refs/tags')
+        uses: actions/upload-artifact@v4
+        with:
+          name: mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}
+          path: mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}.*
+
+  upload_release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+
+      - name: Prepare list of release files & release notes
+        id: makeinfo
+        run: |
+          echo -e "Binary releases (automated builds) below. Max CC in the table means maximum supported compute capability version without dot (i.e. 90 reads as 9.0).\n" > RELEASE_NOTES.txt
+          echo "Filename | Max CC | Build OS | GCC version | NVCC version" >> RELEASE_NOTES.txt
+          echo "--- | --- | --- | --- | ---" >> RELEASE_NOTES.txt
+          cat mfaktc-${{ github.ref_name }}-linux64-cuda*/mfaktc-${{ github.ref_name }}-linux64-cuda*.txt | sort -Vr >> RELEASE_NOTES.txt
+          echo 'RELEASE_FILES<<EOF' > $GITHUB_OUTPUT
+          ls -1 mfaktc-${{ github.ref_name }}-linux64-cuda*/mfaktc-${{ github.ref_name }}-linux64-cuda*.zip | sort -Vr >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - name: Make and upload release
+        uses: softprops/action-gh-release@v2.2.1
+        with:
+          fail_on_unmatched_files: false
+          files: |
+            ${{ steps.makeinfo.outputs.RELEASE_FILES }}
+          preserve_order: true
+          generate_release_notes: true
+          body_path: RELEASE_NOTES.txt
+          make_latest: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,113 @@
+name: Build mfaktc software
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: "nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}"
+
+    permissions:
+      contents: write
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      matrix:
+        sys:
+          - { cuda_version: '12.8.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.6.3', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.6.2', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.6.1', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.6.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.5.1', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.5.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.4.1', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.4.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.3.2', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.3.1', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.3.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.2.2', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.2.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.1.1', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.1.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.0.1', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.0.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '11.8.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '11.7.1', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '11.6.2', ct_os: 'ubuntu20.04' }
+          - { cuda_version: '11.6.1', ct_os: 'ubuntu20.04' }
+          - { cuda_version: '11.5.2', ct_os: 'ubuntu20.04' }
+          - { cuda_version: '11.4.3', ct_os: 'ubuntu20.04' }
+          - { cuda_version: '11.3.1', ct_os: 'ubuntu20.04' }
+          - { cuda_version: '11.2.2', ct_os: 'ubuntu20.04' }
+          - { cuda_version: '11.1.1', ct_os: 'ubuntu20.04' }
+          - { cuda_version: '11.0.3', ct_os: 'ubuntu20.04' }
+          - { cuda_version: '10.2', ct_os: 'ubuntu18.04' }
+          - { cuda_version: '9.2', ct_os: 'ubuntu18.04' }
+          - { cuda_version: '8.0', ct_os: 'ubuntu16.04' }
+
+    steps:
+
+    - name: Fix GPG keys for NVidia repo on Ubuntu 16.04
+      if: matrix.sys.ct_os == 'ubuntu16.04'
+      run: |
+        apt update || /bin/true
+        apt install -y wget
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
+        apt-key add 3bf863cc.pub
+
+    - name: Update & install required packages inside the container
+      run: |
+        apt update
+        apt -y full-upgrade
+        apt install -y build-essential curl git make python3 sudo unzip wget zip
+
+    - name: Checkout repo
+      if: matrix.sys.ct_os == 'ubuntu22.04' || matrix.sys.ct_os == 'ubuntu20.04'
+      uses: actions/checkout@v3
+
+    - name: Checkout repo
+      if: matrix.sys.ct_os != 'ubuntu22.04' && matrix.sys.ct_os != 'ubuntu20.04'
+      uses: actions/checkout@v1
+
+    - name: Update Makefile
+      id: update_makefile
+      shell: bash
+      run: |
+        echo -n "Checking for nvcc maximum supported CC... "
+        export CCMAX=$(nvcc --help | grep -Eoe "compute_[0-9]{2}" | cut -d '_' -f2 | sort -un | tail -n1)
+        echo $CCMAX
+        echo "CCMAX=$CCMAX" >> $GITHUB_OUTPUT
+
+        echo "Removing unsupported CCs (> $CCMAX) from the Makefile"
+        for cc in $(grep -E '^NVCCFLAGS \+=.*?compute_[0-9]{2}' src/Makefile | grep -Eoe 'compute_[0-9]{2}' | tr -d '\r' | cut -d '_' -f2 | xargs); do
+          if [[ $cc -gt $CCMAX ]]; then
+            echo "Removing CC $cc"
+            sed -i -E "/^NVCCFLAGS \+=.*?compute_$cc/d" src/Makefile
+          fi
+        done
+
+        echo "Adding libraries to LDFLAGS to support static build on older Ubuntu versions..."
+        sed -i -E 's/^(LDFLAGS = .*? -lcudart_static) (.*)/\1 -ldl -lrt -lpthread \2/' src/Makefile
+
+    - name: Build from sources
+      run: cd src && make -j$(nproc)
+
+    - name: Prepare zip archive for release
+      if: startsWith(github.ref, 'refs/tags')
+      run: zip -9 -j mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}.zip *
+
+    - name: Make and upload release
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/tags')
+      with:
+        fail_on_unmatched_files: false
+        generate_release_notes: true
+        files: mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}.zip
+        append_body: true
+        body: " - mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}.zip: max CC ${{ steps.update_makefile.outputs.CCMAX }}, build os ${{ matrix.sys.ct_os }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,19 +6,19 @@ on:
   workflow_dispatch:
 
 jobs:
-# Begin job "build"
-  build:
+# Begin job "build-linux"
+  build-linux:
     runs-on: ubuntu-latest
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
-      fail-fast: false
+      fail-fast: true
 
       matrix:
         sys:
           # Specified version combination must exist as CUDA container image from NVidia: nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}
           # Available versions can be found here: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags (note that only Ubuntus are supported by this action)
-          - { cuda_version: '12.8.0', ct_os: 'ubuntu22.04' }
+          - { cuda_version: '12.8.0', ct_os: 'ubuntu24.04' }
           - { cuda_version: '12.6.3', ct_os: 'ubuntu22.04' }
           - { cuda_version: '12.6.2', ct_os: 'ubuntu22.04' }
           - { cuda_version: '12.6.1', ct_os: 'ubuntu22.04' }
@@ -55,6 +55,7 @@ jobs:
       # As a workaround, Docker containers will be launched separately, running build related actions inside the container via 'docker exec', while generic actions will run on the
       # host runner VM itself.
       CONTAINER: "nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}"
+      base_name: mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}
 
     steps:
 
@@ -72,6 +73,7 @@ jobs:
           docker exec build-container bash -c "$SCRIPT"
 
       - name: Update & install required packages inside the container
+        id: packages
         env:
           SCRIPT: |
             apt update
@@ -82,31 +84,16 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Update Makefile
-        id: update_makefile
+      - name: Prepare sources and gather info
+        id: prepare
         shell: bash
         env:
           SCRIPT: |
             cd /workspace
-            echo -n "Checking for nvcc maximum supported CC... "
-            export CCMAX=$(nvcc --help | grep -Eoe "compute_[0-9]{2}" | cut -d '_' -f2 | sort -un | tail -n1)
-            echo $CCMAX
-            echo "CCMAX=$CCMAX" >> GITHUB_OUTPUT
-
-            echo "Removing unsupported CCs (> $CCMAX) from the Makefile"
-            for cc in $(grep -E '^NVCCFLAGS \+=.*?compute_[0-9]{2}' src/Makefile | grep -Eoe 'compute_[0-9]{2}' | tr -d '\r' | cut -d '_' -f2 | xargs); do
-              if [[ $cc -gt $CCMAX ]]; then
-                echo "Removing CC $cc"
-                sed -i -E "/^NVCCFLAGS \+=.*?compute_$cc/d" src/Makefile
-              fi
-            done
-
-            echo "Adding libraries to LDFLAGS to support static build on older Ubuntu versions..."
-            sed -i -E 's/^(LDFLAGS = .*? -lcudart_static) (.*)/\1 -ldl -lrt -lpthread \2/' src/Makefile
+            bash .github/workflows/scripts/build_helper.sh ${{ matrix.sys.cuda_version }}
         run: |
           docker exec build-container bash -c "$SCRIPT"
-          cat GITHUB_OUTPUT > $GITHUB_OUTPUT
-          rm -f GITHUB_OUTPUT
+          cat .github/workflows/scripts/build_helper.sh.out >> $GITHUB_OUTPUT
 
       - name: Build from sources
         env:
@@ -117,23 +104,111 @@ jobs:
         env:
           SCRIPT: |
             cd /workspace
-            export BASE_NAME="mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}"
-            zip -9 -j ${BASE_NAME}.zip *
-            echo "[${BASE_NAME}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${BASE_NAME}.zip) | \
-            ${{ steps.update_makefile.outputs.CCMAX }} | ${{ matrix.sys.ct_os }} | $(gcc --version | head -n1) | $(nvcc --version | tail -n1)" > ${BASE_NAME}.txt
+            zip -9 -j ${{ env.base_name }}.zip *
+            echo "[${{ env.base_name }}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.base_name }}.zip) | \
+            ${{ matrix.sys.os.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
+            ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ env.base_name }}.txt
         run: docker exec build-container bash -c "$SCRIPT"
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}
-          path: mfaktc-${{ github.ref_name }}-linux64-cuda${{ matrix.sys.cuda_version }}.*
-# End job "build"
+          name: ${{ env.base_name }}
+          path: ${{ env.base_name }}.*
+# End job "build-linux"
 
-# Begin job "upload_release"
-  upload_release:
+# Begin job "build-win"
+  build-win:
+    runs-on: ${{ matrix.sys.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: true
+
+      matrix:
+        # Available version can be viewed at the Jimver/cuda-toolkit action sources:
+        # https://github.com/Jimver/cuda-toolkit/blob/v0.2.21/src/links/windows-links.ts
+        sys:
+          - { cuda_version: '12.8.0', os: 'windows-2022' }
+          - { cuda_version: '12.6.3', os: 'windows-2022' }
+          - { cuda_version: '12.5.1', os: 'windows-2022' }
+          - { cuda_version: '12.4.1', os: 'windows-2022' }
+          - { cuda_version: '12.3.2', os: 'windows-2022' }
+          - { cuda_version: '12.2.2', os: 'windows-2022' }
+          - { cuda_version: '12.1.1', os: 'windows-2022' }
+          - { cuda_version: '12.0.1', os: 'windows-2022' }
+          - { cuda_version: '11.8.0', os: 'windows-2022' }
+          - { cuda_version: '11.7.0', os: 'windows-2022' }
+          - { cuda_version: '11.6.2', os: 'windows-2022' }
+          - { cuda_version: '11.5.2', os: 'windows-2022' }
+          - { cuda_version: '11.4.4', os: 'windows-2022' }
+          - { cuda_version: '11.3.1', os: 'windows-2022' }
+          - { cuda_version: '11.2.2', os: 'windows-2019' }
+          - { cuda_version: '11.1.1', os: 'windows-2019' }
+          - { cuda_version: '11.0.1', os: 'windows-2019' }
+#          - { cuda_version: '10.0.130', os: 'windows-2019' }
+#          - { cuda_version: '9.2.148', os: 'windows-2019' }
+#          - { cuda_version: '8.0.61', os: 'windows-2019' }
+
+    env:
+      base_name: mfaktc-${{ github.ref_name }}-win64-cuda${{ matrix.sys.cuda_version }}
+
+    steps:
+      - name: Installing CUDA Toolkit
+        id: cuda-toolkit
+        uses: Jimver/cuda-toolkit@v0.2.21
+        with:
+          cuda: ${{ matrix.sys.cuda_version }}
+#          sub-packages: '[ "nvcc", "visual_studio_integration", "cudart" ]'
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Prepare sources and gather info
+        id: prepare
+        shell: bash
+        run: |
+          bash .github/workflows/scripts/build_helper.sh ${{ matrix.sys.cuda_version }}
+          cat .github/workflows/scripts/build_helper.sh.out >> $GITHUB_OUTPUT
+
+      # MSVC 2022 installed on Windows 2022 Github Runner has PowerShell script for a Dev Shell.
+      - name: Build from sources (PowerShell with MSVC 2022)
+        if: ${{ matrix.sys.os == 'windows-2022' }}
+        shell: powershell
+        run: |
+          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' -Arch amd64 -HostArch amd64
+          cd "${{ github.workspace }}\src"
+          make SHELL="powershell.exe" -f Makefile.win
+
+      # MSVC 2019 on Windows 2019 has similar script, but it doesn't allows setting arch & host_arch and defaults to x86 (32 bit) env.
+      # So we have to run bat file for the env, but Make uses PowerShell afterward because it's much better at handling long paths &
+      # quotes when invoked from Make.
+      - name: Build from sources (cmd.exe with MSVC 2019)
+        if: ${{ matrix.sys.os == 'windows-2019' }}
+        shell: cmd
+        run: |
+          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" & cd src & make SHELL="powershell.exe" -f Makefile.win
+
+      - name: Prepare build archive with description
+        shell: bash
+        run: |
+          choco install -y --no-progress zip
+          zip -9 -j "${{ env.base_name }}.zip" *
+          echo "[${{ env.base_name }}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.base_name }}.zip) | \
+          ${{ matrix.sys.os.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
+          ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ env.base_name }}.txt
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.base_name }}
+          path: ${{ env.base_name }}.*
+# End job "build-win"
+
+# Begin job "upload-release"
+  upload-release:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: build
+    needs: [ build-linux, build-win ]
     runs-on: ubuntu-latest
 
     permissions:
@@ -147,12 +222,15 @@ jobs:
       - name: Prepare list of release files & release notes
         id: makeinfo
         run: |
-          echo -e "Binary releases (automated builds) below. Max CC in the table means maximum supported compute capability version without dot (i.e. 90 reads as 9.0).\n" > RELEASE_NOTES.txt
-          echo "Filename | Max CC | Build OS | GCC version | NVCC version" >> RELEASE_NOTES.txt
-          echo "--- | --- | --- | --- | ---" >> RELEASE_NOTES.txt
-          cat mfaktc-${{ github.ref_name }}-linux64-cuda*/mfaktc-${{ github.ref_name }}-linux64-cuda*.txt | sort -Vr >> RELEASE_NOTES.txt
+          echo "Binary releases (automated builds) below." > RELEASE_NOTES.txt
+          echo "Compute Capability (CC) in the table means minimum and maximum versions supported." >> RELEASE_NOTES.txt
+          echo "CC versions are listed without the dot (i.e. 90 means 9.0 compute capability)." >> RELEASE_NOTES.txt
+          echo >> RELEASE_NOTES.txt
+          echo "File | Compute Capability | CUDA version | Build OS | Compiler version | NVCC version" >> RELEASE_NOTES.txt
+          echo "--- | --- | --- | --- | --- | ---" >> RELEASE_NOTES.txt
+          cat mfaktc-${{ github.ref_name }}-*-cuda*/mfaktc-${{ github.ref_name }}-*-cuda*.txt | sort -Vr >> RELEASE_NOTES.txt
           echo 'RELEASE_FILES<<EOF' > $GITHUB_OUTPUT
-          ls -1 mfaktc-${{ github.ref_name }}-linux64-cuda*/mfaktc-${{ github.ref_name }}-linux64-cuda*.zip | sort -Vr >> $GITHUB_OUTPUT
+          ls -1 mfaktc-${{ github.ref_name }}-*-cuda*/mfaktc-${{ github.ref_name }}-*-cuda*.zip | sort -Vr >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Make and upload release
@@ -165,3 +243,5 @@ jobs:
           generate_release_notes: true
           body_path: RELEASE_NOTES.txt
           make_latest: true
+# End job "upload-release"
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,6 +178,7 @@ jobs:
         run: |
           & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' -Arch amd64 -HostArch amd64
           cd "${{ github.workspace }}\src"
+          Copy-Item mfaktc.ini ..
           make SHELL="powershell.exe" -f Makefile.win
 
       # MSVC 2019 on Windows 2019 has similar script, but it doesn't allows setting arch & host_arch and defaults to x86 (32 bit) env.
@@ -187,7 +188,7 @@ jobs:
         if: ${{ matrix.sys.os == 'windows-2019' }}
         shell: cmd
         run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" & cd src & make SHELL="powershell.exe" -f Makefile.win
+          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" & cd src & copy mfaktc.ini .. & make SHELL="powershell.exe" -f Makefile.win
 
       - name: Prepare build archive with description
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
             cd /workspace
             zip -9 -j ${{ env.base_name }}.zip *
             echo "[${{ env.base_name }}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.base_name }}.zip) | \
-            ${{ matrix.sys.os.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
+            ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
             ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ env.base_name }}.txt
         run: docker exec build-container bash -c "$SCRIPT"
 
@@ -196,7 +196,7 @@ jobs:
           choco install -y --no-progress zip
           zip -9 -j "${{ env.base_name }}.zip" *
           echo "[${{ env.base_name }}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.base_name }}.zip) | \
-          ${{ matrix.sys.os.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
+          ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
           ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ env.base_name }}.txt
 
       - name: Upload build artifacts
@@ -227,7 +227,7 @@ jobs:
           echo "Compute Capability (CC) in the table means minimum and maximum versions supported." >> RELEASE_NOTES.txt
           echo "CC versions are listed without the dot (i.e. 90 means 9.0 compute capability)." >> RELEASE_NOTES.txt
           echo >> RELEASE_NOTES.txt
-          echo "File | Compute Capability | CUDA version | Build OS | Compiler version | NVCC version" >> RELEASE_NOTES.txt
+          echo "File | CUDA version | Compute Capability | Build OS | Compiler version | NVCC version" >> RELEASE_NOTES.txt
           echo "--- | --- | --- | --- | --- | ---" >> RELEASE_NOTES.txt
           cat mfaktc-${{ github.ref_name }}-*-cuda*/mfaktc-${{ github.ref_name }}-*-cuda*.txt | sort -Vr >> RELEASE_NOTES.txt
           echo 'RELEASE_FILES<<EOF' > $GITHUB_OUTPUT

--- a/.github/workflows/scripts/build_helper.sh
+++ b/.github/workflows/scripts/build_helper.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# build_helper.sh
+# This script are used by the CI/CD builds with Github Actions workflow.
+# It gathers some info on software versions and saves it to file 
+# build_helper.sh.out which are later used by the actions workflow.
+# It also patches Makefiles to support building under Github Action
+# runners environment and compile kernels for every compute capability
+# device supported by the NVCC.
+#
+# Copyright (c) 2025 NStorm (https://github.com/N-Storm/)
+# This file is part of mfaktc.
+# Copyright (C) 2009, 2010, 2011  Oliver Weihe (o.weihe@t-online.de)
+#
+# mfaktc is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mfaktc is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+if [[ -z "$1" ]]; then
+  echo "Usage: $0 <CUDA version>" >&2
+  exit 1
+fi
+
+# Windows may have it's sort first on PATH, so set this var to the full path 
+# to GNU sort to avoid having writing full path every time.
+export GSORT='/usr/bin/sort'
+
+declare -a CUDA_VERSION
+CUDA_VERSION=( $(echo "$1" | head -n1 | grep -Eom1 -e '^[1-9]([0-9])?\.[0-9]{1,2}(\.[0-9]{1,3})?$' | tr '.' ' ') )
+if [[ -z "${CUDA_VERSION[*]}" ]]; then
+  echo "ERROR! Can't parse CUDA version $1" >&2
+  exit 2
+fi
+
+eval $(echo -e "CUDA_VER_MAJOR=${CUDA_VERSION[0]}\nCUDA_VER_MINOR=${CUDA_VERSION[1]}" | tee $0.out)
+CUDA_VER="${CUDA_VER_MAJOR}${CUDA_VER_MINOR}"
+
+# Starting from 11.0.0 CUDA has --list-gpu-arch flag.
+# For older versions we have to grep out supported CC versions from help.
+[ $CUDA_VER -gt 110 ] && NVCC_OPTS='--list-gpu-arch' || NVCC_OPTS='--help'
+NVCC_REGEX='compute_[1-9][0-9]{1,2}'
+# Special case with CUDA 11.0.x. It's help lists compute_32 and higher, but only CCs from 35 are supported.
+[ $CUDA_VER -eq 110 ] && NVCC_REGEX='compute_(3[5-9]|[4-9][0-9])'
+
+declare -a CC_LIST
+CC_LIST=( $(nvcc $NVCC_OPTS | grep -Eoe "$NVCC_REGEX" | cut -d '_' -f2 | $GSORT -un | xargs) )
+if [ ${#CC_LIST[*]} -eq 0 ]; then
+  echo "ERROR! Unable to parse a list of CCs" >&2
+  exit 3
+elif [ ${#CC_LIST[*]} -lt 3 ]; then
+  echo "WARN Number of supported CC versions less than 3" >&2
+fi
+
+echo "All supported CCs: ${CC_LIST[*]}, CC_MIN=${CC_LIST[0]}, CC_MAX=${CC_LIST[-1]}"
+echo -e "CC_LIST=\"${CC_LIST[*]}\"\nCC_MIN=${CC_LIST[0]}\nCC_MAX=${CC_LIST[-1]}" >> $0.out
+
+echo 'Removing NVCCFLAGS strings with CC arch entries from the Makefile & Makefile.win and populating with discovered supported values.'
+sed -i '/^NVCCFLAGS += --generate-code arch=compute.*/d' src/Makefile.win src/Makefile
+for CC in "${CC_LIST[@]}"; do
+  sed -i "/^NVCCFLAGS = .*\$/a NVCCFLAGS += --generate-code arch=compute_${CC},code=sm_${CC}" src/Makefile src/Makefile.win
+done
+
+if [ $CUDA_VER -ge 110 ]; then
+  echo 'Adding NVCCFLAGS to allow unsupported MSVC compiler versions...'
+  sed -i '/^NVCCFLAGS = .*/a NVCCFLAGS += -allow-unsupported-compiler -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH' src/Makefile.win
+fi
+if [ $CUDA_VER -lt 120 ]; then
+  echo "Adding libraries to LDFLAGS to support static build on older Ubuntu versions..."
+  sed -i -E 's/^(LDFLAGS = .*? -lcudart_static) (.*)/\1 -ldl -lrt -lpthread \2/' src/Makefile
+fi
+
+echo 'Gathering version info on generic compiler and nvcc...'
+if [[ -x "$(which vswhere.exe)" ]]; then
+  CC_VSPROD="$(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property displayName)"
+  COMPILER_VER="${CC_VSPROD}, $(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion)"
+elif [[ -x "$(which powershell.exe)" ]]; then
+  CC_VSINFO="$(powershell -Command Get-VSSetupInstance)"
+  CC_VSPROD="$(echo $CC_VSINFO | grep DisplayName | cut -d':' -f2 | xargs)"
+  COMPILER_VER="${CC_VSPROD}, $(echo $CC_VSINFO | grep InstallationVersion | cut -d':' -f2 | xargs)"
+else
+  COMPILER_VER="$(gcc --version | head -n1)"
+  OS_VER="$(grep PRETTY_NAME /etc/os-release | cut -d'=' -f2- | tr -d '"')"
+fi
+
+NVCC_VER="$(nvcc --version | tail -n1)"
+
+if [[ -x "$(which powershell.exe)" ]]; then
+  OS_VER="$(powershell -Command "[System.Environment]::OSVersion.VersionString")"
+fi
+
+echo -e "COMPILER_VER=$COMPILER_VER\nNVCC_VER=$NVCC_VER\nOS_VER=${OS_VER}" | tee -a $0.out

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -1,7 +1,5 @@
-CUDA_DIR = "$(CUDA_PATH)"
-
 CC = cl
-CFLAGS = /Ox /Oy /W2 /fp:fast /I$(CUDA_DIR)\include /I$(CUDA_DIR)\include\cudart /nologo
+CFLAGS = /Ox /Oy /W2 /fp:fast /I"$(CUDA_PATH)\include" /I"$(CUDA_PATH)\include\cudart" /nologo
 
 NVCCFLAGS = -m64 --ptxas-options=-v
 CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /Ox" $(NVCCFLAGS)
@@ -33,7 +31,7 @@ CUSRC = tf_72bit.cu tf_96bit.cu tf_barrett96.cu tf_barrett96_gs.cu gpusieve.cu
 CUOBJS = $(CUSRC:.cu=.obj) tf_75bit.obj
 COBJS  = $(CSRC:.c=.obj)
 
-LIBS = $(CUDA_DIR)\lib\x64\cudart_static.lib
+LIBS = "$(CUDA_PATH)\lib\x64\cudart_static.lib"
 
 INSTALL = copy
 


### PR DESCRIPTION
This PR introduces automated builds using GitHub Actions (GA) runners, with support for uploading resulting binaries to the "Releases" section, along with release notes generation. The latter happens when a tag is created, but this can be adjusted to match a specific template or be triggered manually.

Supported configurations:
- **Windows x64**: CUDA 11.0 and higher  
- **Linux x86_64**: CUDA 8.0 and higher  

Building 32-bit binaries and supporting older CUDA versions within GA runners doesn’t seem reasonable to me. The time required to implement and test these would likely outweigh any demand. If possible at all—since, for example, Windows GA runners are only available in two flavors (MSVC 2019 & 2022). The currently supported versions should cover any hardware still useful for factoring.

Currently, I’ve included one target version per **MAJOR.MINOR**, selecting the latest **.PATCHLEVEL** available. In other words, for every **X.Y.z**, I pick one **X.Y** with the highest available **.z**. However, this can be easily configured in the [`.github/workflows/build.yml`](https://github.com/N-Storm/mfaktc/blob/511f1868805aa30b2aa8ae2f785693e766a77cdc/.github/workflows/build.yml). I’ve left comments there with links to available versions.  

It’s also possible to add a release flag so that generic builds run for every version listed, but only those marked with this flag get uploaded to the releases section. This is useful if you prefer not to upload too many releases but still want continuous builds to gather feedback on the build process as further changes are made. Builds that aren’t uploaded can still be downloaded by repository members with write permissions under **Actions → [Build] → Artifacts**, where they remain available for up to 90 days (configurable in the repository settings on the GitHub web interface).

I had to [slightly modify `Makefile.win`](https://github.com/primesearch/mfaktc/commit/a2a45c50d793074dec8594c5651ce410e0dd7dd5#diff-fd95cf91a5934e10c646e04552d16af97ddc71457ff76089a2090626d1d5e683L1) to fix path and quoting issues for CUDA. Instead of using an intermediate `CUDA_DIR`, I switched to using `CUDA_PATH` directly. This should be safe for manual builds as well, but I haven’t tested it. If this change breaks manual builds or is otherwise unacceptable, it can be moved to a build helper script—modifying a local copy of `Makefile.win` during the build while keeping the repository version unchanged.

### Example releases built using this workflow:
- [0.23.2pre4](https://github.com/N-Storm/mfaktc/releases/tag/0.23.2pre4)  
- Recently added **0.24.0** test branch builds as well, if `Makefile.win` changes from this PR are merged into it:  
  [Build log](https://github.com/N-Storm/mfaktc/actions/runs/13499381031/job/37715598754) + [Release link](https://github.com/N-Storm/mfaktc/releases/tag/0.24.0pre1)  

_Note: The 0.24.0 test branch release was built before a fix for the table was committed, so columns with CUDA versions are missing and Compute Capability is misaligned. This has already been fixed in this PR, but I haven’t rebuilt 0.24.0 branch on my fork._  

Feel free to PM me on the forums if you have any questions.