### PR TITLE
Bump CUDA version to 12.8.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,8 @@ jobs:
         sys:
           # Specified version combination must exist as CUDA container image from Nvidia: nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}
           # Available versions can be found here: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags (note that only Ubuntu distros are supported by this action)
-          - { cuda_version: '12.8.0', ct_os: 'ubuntu24.04' }
+          - { cuda_version: '12.8.1', ct_os: 'ubuntu24.04' }
+          # - { cuda_version: '12.8.0', ct_os: 'ubuntu24.04' }
           - { cuda_version: '12.6.3', ct_os: 'ubuntu22.04' }
           # - { cuda_version: '12.6.2', ct_os: 'ubuntu22.04' }
           # - { cuda_version: '12.6.1', ct_os: 'ubuntu22.04' }
@@ -171,7 +172,7 @@ jobs:
         # Available versions can be viewed at the Jimver/cuda-toolkit action sources:
         # https://github.com/Jimver/cuda-toolkit/blob/v0.2.21/src/links/windows-links.ts
         sys:
-          - { cuda_version: '12.8.0', os: 'windows-2022' }
+          - { cuda_version: '12.8.1', os: 'windows-2022' }
           - { cuda_version: '12.6.3', os: 'windows-2022' }
           - { cuda_version: '12.5.1', os: 'windows-2022' }
           - { cuda_version: '12.4.1', os: 'windows-2022' }
@@ -202,7 +203,7 @@ jobs:
 
       - name: Install CUDA Toolkit
         id: cuda-toolkit
-        uses: Jimver/cuda-toolkit@v0.2.21
+        uses: Jimver/cuda-toolkit@v0.2.22
         with:
           cuda: ${{ matrix.sys.cuda_version }}
           sub-packages: ${{ startsWith(matrix.sys.cuda_version, '8.') && '[]' || '[ "nvcc", "cudart" ]' }}


### PR DESCRIPTION
This PR updates the CI/CD builds to use the latest CUDA version, 12.8.1, replacing 12.8.0.

The GitHub Action [Jimver/cuda-toolkit](https://github.com/Jimver/cuda-toolkit) was bumped to v0.2.22, which adds support for this CUDA version on Windows builds.

I've tested the Windows build with an RTX 4090 and haven’t encountered any issues.