### PR TITLE
Improved regex match for MFAKTC_VERSION

### DIFF
--- a/.github/workflows/scripts/build_helper.sh
+++ b/.github/workflows/scripts/build_helper.sh
@@ -107,7 +107,8 @@ fi
 NVCC_VER="$(nvcc --version | tail -n1 | sed -E 's/^Build //')"
 
 # Version from src/params.h
-MFAKTC_VER="$(grep -Eo '#define MFAKTC_VERSION "([0-9]\.[0-9]+\.[-0-9a-z]+)"' src/params.h | cut -d '"' -f 2)"
+# Match semver: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+MFAKTC_VER="$(LC_ALL=en_US.utf8 grep -iPo '#define[\s\t]+MFAKTC_VERSION[\s\t]+"v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(?:-?(?:alpha|beta|pre)\.?(?:\d+)?\b)?' src/params.h | cut -d '"' -f 2)"
 
 # Git-formatted version
 GIT_TAG_VER="$(git describe --tags)"


### PR DESCRIPTION
As discussed in https://github.com/primesearch/mfaktc/pull/22#issuecomment-2802128094, this PR changes regex match for mfaktc version from params.h to advanced [regex from semver.org](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string), which should match any valid semantic version: https://regex101.com/r/sVmkG7/1