### PR TITLE
Portable snprintf for VS 2005-2013

### DIFF
--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -26,6 +26,7 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 #include "my_types.h"
 #include "output.h"
 #include "crc.h"
+#include "compatibility.h"
 
 void checkpoint_write(unsigned int exp, int bit_min, int bit_max, int cur_class, int num_factors, int96 factors[MAX_FACTORS_PER_JOB], unsigned long long int bit_level_time)
 /*

--- a/src/compatibility.h
+++ b/src/compatibility.h
@@ -42,3 +42,39 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 #else
   #define my_usleep(A) usleep(A)
 #endif
+
+/* snprintf for VS 2005-2013 https://stackoverflow.com/a/8712996 */
+#if defined(_MSC_VER) && _MSC_VER < 1900
+
+#if !(defined(_INC_STDARG) || defined(_STDARG_H))
+#include <stdarg.h>
+#endif
+
+#define snprintf c99_snprintf
+#define vsnprintf c99_vsnprintf
+
+__inline int c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
+{
+    int count = -1;
+
+    if (size != 0)
+        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
+    if (count == -1)
+        count = _vscprintf(format, ap);
+
+    return count;
+}
+
+__inline int c99_snprintf(char *outBuf, size_t size, const char *format, ...)
+{
+    int count;
+    va_list ap;
+
+    va_start(ap, format);
+    count = c99_vsnprintf(outBuf, size, format, ap);
+    va_end(ap);
+
+    return count;
+}
+
+#endif

--- a/src/output.c
+++ b/src/output.c
@@ -20,7 +20,6 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdio.h>
 #include <stdarg.h>
-#include <stdbool.h>
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
@@ -32,6 +31,15 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 #include "output.h"
 #include "compatibility.h"
 #include "crc.h"
+
+/* Visual C++ introduced stdbool support in VS 2013 */
+#if defined(_MSC_VER) && _MSC_VER < 1800
+#define bool int
+#define true 1
+#define false 0
+#else
+#include <stdbool.h>
+#endif
 
 
 void print_help(char *string)


### PR DESCRIPTION
Also restores stdbool for VS <2013.

Now mfaktc 0.24 can be compiled for CUDA 6.0 :)