### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,6 +307,7 @@ jobs:
             printf '%s\n' ${{ env.base_name }}.zip | sort -Vr
             echo 'EOF'
           } > $GITHUB_OUTPUT
+          ( echo "${{ github.ref_name }}" | grep -qsP "v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(-(?:alpha|beta|pre))" && echo "PRERELEASE=true" || echo "PRERELEASE=false" ) >> $GITHUB_OUTPUT
 
       - name: Create and upload release package
         uses: softprops/action-gh-release@v2.2.1
@@ -315,6 +316,7 @@ jobs:
           files: |
             ${{ steps.makeinfo.outputs.RELEASE_FILES }}
           preserve_order: true
+          prerelease: ${{ steps.makeinfo.outputs.PRERELEASE }}
           generate_release_notes: true
           body_path: RELEASE_NOTES.txt
           make_latest: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,6 +208,7 @@ jobs:
           cuda: ${{ matrix.sys.cuda_version }}
           sub-packages: ${{ startsWith(matrix.sys.cuda_version, '8.') && '[]' || '[ "nvcc", "cudart" ]' }}
           use-local-cache: false
+          use-github-cache: false
 
       - name: Configure path to CUDA
         shell: powershell


### PR DESCRIPTION
- Set prerelease option based on version tag when it matches "-alpha/-beta/-pre" (these are the only allowed suffixes as discussed in #23 ). This resolves #24.
- Disable Github cache for Windows CUDA install which uses deprecated cache action (it was shutdown on Apr 15, 2025).