### PR TITLE
Fix issue where CUDA versions were not detected correctly

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -14,6 +14,7 @@ bug fixes:
 - fix some compilation warnings
 - the maximum number of threads per SM should no longer exceed the limit for
   certain architectures
+- CUDA versions are now correctly detected
 
 build:
 - made the build scripts more robust

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -938,33 +938,41 @@ int main(int argc, char **argv)
   read_config(&mystuff);
 
   int drv_ver, rt_ver;
-  if(mystuff.verbosity >= 1)logprintf(&mystuff, "\nCUDA version info\n");
-  if(mystuff.verbosity >= 1)logprintf(&mystuff, "  binary compiled for CUDA  %d.%d\n", CUDART_VERSION/1000, CUDART_VERSION%100);
   cudaRuntimeGetVersion(&rt_ver);
-  if(mystuff.verbosity >= 1)logprintf(&mystuff, "  CUDA runtime version      %d.%d\n", rt_ver/1000, rt_ver%100);
   cudaDriverGetVersion(&drv_ver);
-  if(mystuff.verbosity >= 1)logprintf(&mystuff, "  CUDA driver version       %d.%d\n", drv_ver/1000, drv_ver%100);
-
-  if(drv_ver < CUDART_VERSION)
-  {
-    logprintf(&mystuff, "ERROR: current CUDA driver version is lower than the CUDA toolkit version used during compile!\n");
-    logprintf(&mystuff, "       Please update your graphics driver.\n");
-    close_log(&mystuff);
-    return 1;
-  }
-  if(rt_ver != CUDART_VERSION)
-  {
-    logprintf(&mystuff, "ERROR: CUDA runtime version must match the CUDA toolkit version used during compile!\n");
-    close_log(&mystuff);
-    return 1;
+  if (mystuff.verbosity >= 1) {
+      int binary_major = CUDART_VERSION / 1000;
+      int binary_minor = (CUDART_VERSION % 1000) / 10;
+      int runtime_major = rt_ver / 1000;
+      int runtime_minor = (rt_ver % 1000) / 10;
+      int driver_major = drv_ver / 1000;
+      int driver_minor = (drv_ver % 1000) / 10;
+      logprintf(&mystuff, "\nCUDA version info\n");
+      logprintf(&mystuff, "  binary compiled for CUDA  %d.%d\n", binary_major, binary_minor);
+      logprintf(&mystuff, "  CUDA runtime version      %d.%d\n", runtime_major, runtime_minor);
+      logprintf(&mystuff, "  CUDA driver version       %d.%d\n", driver_major, driver_minor);
   }
 
-  if(cudaSetDevice(devicenumber)!=cudaSuccess)
+  if (drv_ver < CUDART_VERSION)
   {
-    logprintf(&mystuff, "cudaSetDevice(%d) failed\n",devicenumber);
-    print_last_CUDA_error(&mystuff);
-    close_log(&mystuff);
-    return 1;
+      logprintf(&mystuff, "ERROR: current CUDA driver version is lower than the CUDA toolkit version used during compile!\n");
+      logprintf(&mystuff, "       Please update your graphics driver.\n");
+      close_log(&mystuff);
+      return 1;
+  }
+  if (rt_ver != CUDART_VERSION)
+  {
+      logprintf(&mystuff, "ERROR: CUDA runtime version must match the CUDA toolkit version used during compile!\n");
+      close_log(&mystuff);
+      return 1;
+  }
+
+  if (cudaSetDevice(devicenumber) != cudaSuccess)
+  {
+      logprintf(&mystuff, "cudaSetDevice(%d) failed\n", devicenumber);
+      print_last_CUDA_error(&mystuff);
+      close_log(&mystuff);
+      return 1;
   }
 
   cudaGetDeviceProperties(&deviceinfo, devicenumber);
@@ -973,14 +981,14 @@ int main(int argc, char **argv)
 
   mystuff.max_shared_memory = (int)deviceinfo.sharedMemPerMultiprocessor;
 
-  if(mystuff.verbosity >= 1)
+  if (mystuff.verbosity >= 1)
   {
-    logprintf(&mystuff, "\nCUDA device info\n");
-    logprintf(&mystuff, "  name                      %s\n",deviceinfo.name);
-    logprintf(&mystuff, "  compute capability        %d.%d\n",deviceinfo.major,deviceinfo.minor);
-    logprintf(&mystuff, "  max threads per block     %d\n",deviceinfo.maxThreadsPerBlock);
-    logprintf(&mystuff, "  max shared memory per MP  %d bytes\n", mystuff.max_shared_memory);
-    logprintf(&mystuff, "  number of multiprocessors %d\n", deviceinfo.multiProcessorCount);
+      logprintf(&mystuff, "\nCUDA device info\n");
+      logprintf(&mystuff, "  name                      %s\n", deviceinfo.name);
+      logprintf(&mystuff, "  compute capability        %d.%d\n", deviceinfo.major, deviceinfo.minor);
+      logprintf(&mystuff, "  max threads per block     %d\n", deviceinfo.maxThreadsPerBlock);
+      logprintf(&mystuff, "  max shared memory per MP  %d bytes\n", mystuff.max_shared_memory);
+      logprintf(&mystuff, "  number of multiprocessors %d\n", deviceinfo.multiProcessorCount);
 
 /* map deviceinfo.major + deviceinfo.minor to number of CUDA cores per MP.
    This is just information, I doesn't matter whether it is correct or not */

--- a/src/output.c
+++ b/src/output.c
@@ -549,7 +549,11 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
     string_length = sprintf(txtstring, "no factor for %s%u from 2^%d to 2^%d", NAME_NUMBERS, mystuff->exponent, mystuff->bit_min, mystuff->bit_max_stage);
   }
 
-  sprintf(details, "CUDA %d.%d arch %d.%d", mystuff->cuda_toolkit / 1000, mystuff->cuda_toolkit % 100, mystuff->cuda_arch / 100, mystuff->cuda_arch % 100);
+  int cuda_major = mystuff->cuda_toolkit / 1000;
+  int cuda_minor = (mystuff->cuda_toolkit % 1000) / 10;
+  int arch_major = mystuff->cuda_arch / 100;
+  int arch_minor = (mystuff->cuda_arch % 100) / 10;
+  sprintf(details, "CUDA %d.%d arch %d.%d", cuda_major, cuda_minor, arch_major, arch_minor);
 
   string_length += sprintf(txtstring + string_length, " [mfaktc %s %s %s]", MFAKTC_VERSION, mystuff->stats.kernelname, details);
 
@@ -580,57 +584,65 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
 }
 
 
-void print_factor(mystuff_t *mystuff, int factor_number, char *factor)
+void print_factor(mystuff_t* mystuff, int factor_number, char* factor)
 {
-  char UID[110]; /* 50 (V5UserID) + 50 (ComputerID) + 8 + spare */
-  char string[200];
-  int max_class_counter, string_length = 0, checksum;
-  FILE *resultfile = NULL;
+    char UID[110]; /* 50 (V5UserID) + 50 (ComputerID) + 8 + spare */
+    char string[200];
+    int max_class_counter, string_length = 0, checksum;
+    FILE* resultfile = NULL;
 
 #ifndef MORE_CLASSES
-  max_class_counter = 96;
+    max_class_counter = 96;
 #else
-  max_class_counter = 960;
+    max_class_counter = 960;
 #endif
 
-  if(mystuff->V5UserID[0] && mystuff->ComputerID[0])
-    sprintf(UID, "UID: %s/%s, ", mystuff->V5UserID, mystuff->ComputerID);
-  else
-    UID[0]=0;
+    if (mystuff->V5UserID[0] && mystuff->ComputerID[0])
+        sprintf(UID, "UID: %s/%s, ", mystuff->V5UserID, mystuff->ComputerID);
+    else
+        UID[0] = 0;
 
 
-  if(mystuff->mode == MODE_NORMAL)
-  {
-    resultfile = fopen(mystuff->resultfile, "a");
-    if(mystuff->print_timestamp == 1 && factor_number == 0)print_timestamp(resultfile);
-  }
-
-  if(factor_number < 10)
-  {
-    string_length = sprintf(string, "%s%u has a factor: %s [TF:%d:%d%s:mfaktc %s %s CUDA %d.%d arch %d.%d]", NAME_NUMBERS, mystuff->exponent, factor, \
-                            mystuff->bit_min, mystuff->bit_max_stage, ((mystuff->stopafterfactor == 2) && (mystuff->stats.class_counter <  max_class_counter)) ? "*" : "" , \
-                            MFAKTC_VERSION, mystuff->stats.kernelname, mystuff->cuda_toolkit / 1000, mystuff->cuda_toolkit % 100, mystuff->cuda_arch / 100, mystuff->cuda_arch % 100);
-
-    checksum = crc32_checksum(string, string_length);
-    sprintf(string + string_length, " %08X", checksum);
-
-    if(mystuff->mode != MODE_SELFTEST_SHORT)
+    if (mystuff->mode == MODE_NORMAL)
     {
-      if(mystuff->printmode == 1 && factor_number == 0)printf("\n");
-      printf("%s\n", string);
+        resultfile = fopen(mystuff->resultfile, "a");
+        if (mystuff->print_timestamp == 1 && factor_number == 0)print_timestamp(resultfile);
     }
-    if(mystuff->mode == MODE_NORMAL)
-    {
-      fprintf(resultfile, "%s%s\n", UID, string);
-    }
-  }
-  else /* factor_number >= 10 */
-  {
-    if(mystuff->mode != MODE_SELFTEST_SHORT)      printf("%s%u: %d additional factors not shown\n",      NAME_NUMBERS, mystuff->exponent, factor_number-10);
-    if(mystuff->mode == MODE_NORMAL)fprintf(resultfile,"%s%s%u: %d additional factors not shown\n", UID, NAME_NUMBERS, mystuff->exponent, factor_number-10);
-  }
 
-  if(mystuff->mode == MODE_NORMAL)fclose(resultfile);
+    if (factor_number < 10)
+    {
+        int cuda_major = mystuff->cuda_toolkit / 1000;
+        int cuda_minor = (mystuff->cuda_toolkit % 1000) / 10;
+        int arch_major = mystuff->cuda_arch / 100;
+        int arch_minor = (mystuff->cuda_arch % 100) / 10;
+        string_length = sprintf(string, "%s%u has a factor: %s [TF:%d:%d%s:mfaktc %s %s CUDA %d.%d arch %d.%d]", NAME_NUMBERS, mystuff->exponent, factor, \
+            mystuff->bit_min, mystuff->bit_max_stage, ((mystuff->stopafterfactor == 2) && (mystuff->stats.class_counter < max_class_counter)) ? "*" : "", \
+            MFAKTC_VERSION, mystuff->stats.kernelname, cuda_major, cuda_minor, arch_major, arch_minor);
+
+        checksum = crc32_checksum(string, string_length);
+        sprintf(string + string_length, " %08X", checksum);
+
+        if (mystuff->mode != MODE_SELFTEST_SHORT)
+        {
+            if (mystuff->printmode == 1 && factor_number == 0) {
+                printf("\n");
+            }
+            printf("%s\n", string);
+        }
+        if (mystuff->mode == MODE_NORMAL)
+        {
+            fprintf(resultfile, "%s%s\n", UID, string);
+        }
+    }
+    else /* factor_number >= 10 */
+    {
+        if (mystuff->mode != MODE_SELFTEST_SHORT)      printf("%s%u: %d additional factors not shown\n", NAME_NUMBERS, mystuff->exponent, factor_number - 10);
+        if (mystuff->mode == MODE_NORMAL)fprintf(resultfile, "%s%s%u: %d additional factors not shown\n", UID, NAME_NUMBERS, mystuff->exponent, factor_number - 10);
+    }
+
+    if (mystuff->mode == MODE_NORMAL) {
+        fclose(resultfile);
+    }
 }
 
 

--- a/src/output.c
+++ b/src/output.c
@@ -452,19 +452,19 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
   char aidjson[MAX_LINE_LENGTH+11];
   char userjson[62]; /* 50 (V5UserID) + 11 spare + null character */
   char computerjson[66];  /* 50 (ComputerID) + 15 spare + null character */
-  char factorjson[513];
+  char factorjson[514];
   char factors_list[500];
   char factors_quote_list[500];
   char osjson[200];
   char details[50];
   char txtstring[200];
-  char json_checksum_string[200];
+  char json_checksum_string[750];
   char timestamp[50];
 
   FILE *txtresultfile=NULL;
 
 #ifndef WAGSTAFF
-  char jsonstring[1100];
+  char jsonstring[1350];
   FILE *jsonresultfile=NULL;
 #endif
 
@@ -519,9 +519,10 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
   }
 
   if (factors_quote_list[0])
-      sprintf(factorjson, ", \"factors\":[%s]", factors_quote_list);
-  else
+      snprintf(factorjson, sizeof(factorjson), ", \"factors\":[%s]", factors_quote_list);
+  else {
       factorjson[0] = 0;
+  }
 
   getOSJSON(osjson);
   get_utc_timestamp(timestamp);
@@ -560,10 +561,10 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
   checksum = crc32_checksum(txtstring, string_length);
   sprintf(txtstring + string_length, " %08X", checksum);
 #ifndef WAGSTAFF
-  sprintf(json_checksum_string, "%u;TF;%s;;%d;%d;%u;;;mfaktc;%s;%s;%s;%s;%s;%s",
+  snprintf(json_checksum_string, sizeof(json_checksum_string), "%u;TF;%s;;%d;%d;%u;;;mfaktc;%s;%s;%s;%s;%s;%s",
       mystuff->exponent, factors_list, mystuff->bit_min, mystuff->bit_max_stage, !partialresult, MFAKTC_VERSION, mystuff->stats.kernelname, details, getOS(), getArchitecture(), timestamp);
   json_checksum = crc32_checksum(json_checksum_string, strlen(json_checksum_string));
-  sprintf(jsonstring, "{\"exponent\":%u, \"worktype\":\"TF\", \"status\":\"%s\", \"bitlo\":%2d, \"bithi\":%2d, \"rangecomplete\":%s%s, \"program\":{\"name\":\"mfaktc\", \"version\":\"%s\", \"subversion\":\"%s\", \"details\":\"%s\"}, \"timestamp\":\"%s\"%s%s%s%s, \"checksum\":{\"version\":%u, \"checksum\":\"%08X\"}}",
+  snprintf(jsonstring, sizeof(jsonstring), "{\"exponent\":%u, \"worktype\":\"TF\", \"status\":\"%s\", \"bitlo\":%2d, \"bithi\":%2d, \"rangecomplete\":%s%s, \"program\":{\"name\":\"mfaktc\", \"version\":\"%s\", \"subversion\":\"%s\", \"details\":\"%s\"}, \"timestamp\":\"%s\"%s%s%s%s, \"checksum\":{\"version\":%u, \"checksum\":\"%08X\"}}",
       mystuff->exponent, factorsfound > 0 ? "F" : "NF", mystuff->bit_min, mystuff->bit_max_stage, partialresult ? "false" : "true", factorjson, MFAKTC_VERSION, mystuff->stats.kernelname, details, timestamp, userjson, computerjson, aidjson, osjson, MFAKTC_CHECKSUM_VERSION, json_checksum);
 #endif
   if(mystuff->mode != MODE_SELFTEST_SHORT)


### PR DESCRIPTION
CUDA version numbers `major.minor[.patch]` are stored as 1,000 * `major` + 10 * `minor` in the code. For example, version 7.5 would be represented by the integer 7050. However, mfaktc calculated the minor version by taking the remainder of the integer divided by 100. This resulted in two issues:

1. mfaktc would still use 10 * `minor` for values 1-9. For instance, CUDA 12.6 showed as version 12.60 in the screen output and results file.
2. A minor version of 10 or above would cause the displayed value to start over from 0.

This PR resolves both cases. It also includes fixes for compilation warnings that are specific to gcc 9.4.0.