### PR TITLE
Bugfix/min blocks per mp 0.23

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -63,6 +63,9 @@ new features:
 - elapsed time is now stored in the .ckp file for accurate progress reporting
 - changed all timestamps to UTC to meet GIMPS results reporting standards
 
+other changes:
+- switched to semantic versioning
+
 version 0.22
 ==============================
 - unreleased

--- a/src/gpusieve.cu
+++ b/src/gpusieve.cu
@@ -64,9 +64,11 @@ const uint32 primesHandledWithSpecialCode = 50;		// Count of primes handled with
 
 // the maximum number of threads per SM is not the same for all architectures,
 // see https://en.wikipedia.org/wiki/CUDA#Technical_specifications for details
-#if __CUDA_ARCH__ == TESLA || __CUDA_ARCH__ == 110
-#define MIN_BLOCKS_PER_MP 3
-#elif  __CUDA_ARCH__ == 120 || __CUDA_ARCH__ == 130 || __CUDA_ARCH__ == TURING
+#if __CUDA_ARCH__ < FERMI || __CUDA_ARCH__ == TURING
+// Compute capability 1.1 only supports 768 threads per multiprocessor, but
+// using minBlocksPerMultiprocessor = 3 may cause a "max reg limit too low"
+// error. Using minBlocksPerMultiprocessor = 4 seems to work and does not
+// result in any NVCC warnings.
 #define MIN_BLOCKS_PER_MP 4
 #else
 #define MIN_BLOCKS_PER_MP 6

--- a/src/my_types.h
+++ b/src/my_types.h
@@ -112,7 +112,7 @@ typedef struct
   int gpu_sieve_size;			/* Size (in bits) of the GPU sieve.  Default is 128M bits. */
   int gpu_sieve_primes;                 /* the actual number of primes using for sieving */
   int gpu_sieve_processing_size;	/* The number of GPU sieve bits each thread in a Barrett kernel will process.  Default is 2K bits. */
-  unsigned int gpu_sieve_min_exp; 	/* the minumum exponent allowed for GPU sieving */
+  unsigned int gpu_sieve_min_exp; 	/* the minimum exponent allowed for GPU sieving */
   unsigned int *d_bitarray;		/* 128M bit array for GPU sieve */
   unsigned int *d_sieve_info;		/* Device array containing compressed info needed for prime number GPU sieves */
   unsigned int *d_calc_bit_to_clear_info; /* Device array containing uncompressed info needed to calculate initial bit-to-clear */


### PR DESCRIPTION
Added a workaround for #32.

@KarlLudwig3485 Please let me know if know if this fixes the issue. If so, then I'll port these changes to `main` as well.