### PR TITLE
Add LegacyResultsTXT option, deprecate legacy results.txt

### DIFF
--- a/src/mfaktc.ini
+++ b/src/mfaktc.ini
@@ -180,6 +180,13 @@ AllowSleep=0
 
 TimeStampInResults=0
 
+# LegacyResultsTxt can be used to enable deprecated results.txt output
+# 0: Do not write the results in deprecated format to results.txt
+# 1: Output the results in deprecated format to results.txt
+#
+# Default: LegacyResultsTxt=0
+LegacyResultsTxt=0
+
 
 # PrintFormat allows the progress output to be customized. You can use
 # any combination of the following format specifications:

--- a/src/my_types.h
+++ b/src/my_types.h
@@ -120,6 +120,7 @@ typedef struct {
     int quit;
     int verbosity; /* 0 = reduced number of screen printfs, 1 = default, >= 2 = some additional printfs */
     int logging;   /* 0 = logging disabled (default), 1 = logging enabled */
+    int legacy_results_txt; /* 0 = output to results.txt disabled (default), 1 = output to results.txt enabled */
 
     int selftestsize;
     int selftestrandomoffset;

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -487,5 +487,22 @@ int read_config(mystuff_t *mystuff)
     }
     mystuff->print_timestamp = i;
 
+    /*****************************************************************************/
+
+    if (my_read_int("mfaktc.ini", "LegacyResultsTxt", &i)) {
+        logprintf(mystuff, "WARNING: Cannot read LegacyResultsTxt from mfaktc.ini, set to 0 by default\n");
+        i = 0;
+    } else if (i < 0 || i > 1) {
+        logprintf(mystuff, "WARNING: LegacyResultsTxt must be 0 or 1, set to 0 by default\n");
+        i = 0;
+    }
+    if (mystuff->verbosity >= 1) {
+        if (i == 0)
+            logprintf(mystuff, "  LegacyResultsTxt          no\n");
+        else
+            logprintf(mystuff, "  LegacyResultsTxt          yes\n");
+    }
+    mystuff->legacy_results_txt = i;
+
     return 0;
 }


### PR DESCRIPTION
This commit adds the LegacyResultsTXT option to mfaktc.ini, disabled by default (set to 0). When disabled, mfaktc will no longer write output to results.txt in the legacy format, which has been superseded by the JSON format.

[This feature was requested](https://www.mersenneforum.org/node/9313?p=1078893#post1078893) by @JamesHeinrich.
@JamesHeinrich, can you please test that it works as expected for you? I've tested it, but won't hurt if anyone else will test it as well.

I'll update this PR and add a changelog record soon.