### PR TITLE
add changes from 0.23.4 to main

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,7 +1,7 @@
 
-version 0.24
+version 0.24.0
 ==============================
-- merge development branches 0.22 and 0.23 together
+- merged development branches 0.22 and 0.23.x
 
 new features:
 - CRC32 checksums in JSON output to reduce invalid results
@@ -18,16 +18,36 @@ bug fixes:
 
 build:
 - made the build scripts more robust
-- new CUDA versions added
+- new CUDA versions added to GitHub Actions workflow (thanks to NStorm)
 
 other changes:
 - dropped support for compute capability 1.x and 32-bit builds
 - replaced deprecated cudaThreadSynchronize() with cudaDeviceSynchronize()
 - removed the debug option "USE_DEVICE_PRINTF"
 - code has been revamped to improve formatting and maintain consistent style
-- deprecated results.txt logging is now disabled by default,
-  please use results.json.txt for submissions; to restore the old behavior
-  and re-enable logging to results.txt, set LegacyResultsTxt=1 in mfaktc.ini.
+  (thanks to NStorm)
+- requested by James Heinrich: results are no longer saved to deprecated
+  results.txt by default (thanks to NStorm)
+  - please use results.json.txt for submissions
+  - set LegacyResultsTxt=1 in mfaktc.ini to restore old behavior and re-enable
+    logging to results.txt
+
+version 0.23.4
+==============================
+- includes changes backported from mfaktc 0.24.0
+
+bug fixes:
+- fixed typos and formatting in output
+- fix some compilation warnings
+- the maximum number of threads per SM should no longer exceed the limit for
+  certain architectures
+- CUDA versions are now correctly detected
+
+build:
+- made the build helper script more robust
+
+other changes:
+- replaced deprecated CUDA function calls
 
 version 0.23.3
 ==============================
@@ -79,6 +99,9 @@ new features:
 - found factors are now stored in the .ckp file
 - elapsed time is now stored in the .ckp file for accurate progress reporting
 - changed all timestamps to UTC to meet GIMPS results reporting standards
+
+other changes
+- switched to semantic versioning
 
 version 0.22
 ==============================

--- a/README.txt
+++ b/README.txt
@@ -73,9 +73,9 @@ Some compile-time settings in the file src/params.h can be changed:
 - the last part contains defines which should *not* be changed unless you
   fully understand them. It is possible to easily screw something up.
 
-Be aware that 32-bit builds are not supported in version 0.24.0 onwards, and in
-CUDA Toolkit 12.2 and later. You will need to use the '0.23' branch and an
-older CUDA Toolkit to build mfaktc for 32 bits. See this thread for details:
+Be aware that mfaktc 0.24.0 and CUDA Toolkit 12.2 drop support for 32-bit
+builds. You will need to use the '0.23' branch and an older CUDA Toolkit to
+compile mfaktc for 32 bits. See this thread for details:
 https://forums.developer.nvidia.com/t/whats-the-last-version-of-the-cuda-toolkit-to-support-32-bit-applications/323106/4
 
 In any case, a 64-bit build is preferred except on some old low-end GPUs.

--- a/src/gpusieve.cu
+++ b/src/gpusieve.cu
@@ -63,9 +63,12 @@ const uint32 primesHandledWithSpecialCode    = 50;          // Count of primes h
 
 // the maximum number of threads per SM is not the same for all architectures,
 // see https://en.wikipedia.org/wiki/CUDA#Technical_specifications for details
-#if __CUDA_ARCH__ == TESLA || __CUDA_ARCH__ == 110
-#define MIN_BLOCKS_PER_MP 3
-#elif __CUDA_ARCH__ == 120 || __CUDA_ARCH__ == 130 || __CUDA_ARCH__ == TURING
+#if __CUDA_ARCH < FERMI || __CUDA_ARCH__ == TURING
+// Compute capability 1.1 only supports 768 threads per multiprocessor, but
+// using minBlocksPerMultiprocessor = 3 may cause a "max reg limit too low"
+// error. Using minBlocksPerMultiprocessor = 4 seems to work and does not
+// result in any NVCC warnings. However, this should not be reachable as
+// devices with compute capability 1.x are not supported in 0.24.0 and later.
 #define MIN_BLOCKS_PER_MP 4
 #else
 #define MIN_BLOCKS_PER_MP 6

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -829,7 +829,7 @@ int main(int argc, char **argv)
             }
 
             if (tmp < 0) {
-                logprintf(&mystuff, "WARNING: minumum verbosity level is 0\n");
+                logprintf(&mystuff, "WARNING: minimum verbosity level is 0\n");
                 tmp = 0;
             }
 

--- a/src/my_types.h
+++ b/src/my_types.h
@@ -107,7 +107,7 @@ typedef struct {
     int gpu_sieve_size; /* Size (in bits) of the GPU sieve.  Default is 128M bits. */
     int gpu_sieve_primes; /* the actual number of primes using for sieving */
     int gpu_sieve_processing_size; /* The number of GPU sieve bits each thread in a Barrett kernel will process.  Default is 2K bits. */
-    unsigned int gpu_sieve_min_exp; /* the minumum exponent allowed for GPU sieving */
+    unsigned int gpu_sieve_min_exp; /* the minimum exponent allowed for GPU sieving */
     unsigned int *d_bitarray; /* 128M bit array for GPU sieve */
     unsigned int *d_sieve_info; /* Device array containing compressed info needed for prime number GPU sieves */
     unsigned int *d_calc_bit_to_clear_info; /* Device array containing uncompressed info needed to calculate initial bit-to-clear */


### PR DESCRIPTION
Ported some changes from 0.23.4 to the `main` branch:
* added the fix for #32
  * devices with compute capability 1.x are not supported in 0.24.0 and later, but this workaround was included for the sake of completeness
* fixed two typos
* updated readme and changelog