### PR TITLE
Enable more compiler optimizations

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,12 +5,12 @@ CUDA_LIB = -L$(CUDA_DIR)/lib64/
 
 # compiler settings for .c files (CPU)
 CC = gcc
-CFLAGS = -Wall -Wextra -O2 $(CUDA_INCLUDE) -malign-double
+CFLAGS = -Wall -Wextra -O3 -flto -malign-double -ffunction-sections -fdata-sections -Wl,--gc-sections $(CUDA_INCLUDE)
 CFLAGS_EXTRA_SIEVE = -funroll-all-loops
 
 # compiler settings for .cu files (GPU)
 NVCC = nvcc
-NVCCFLAGS = $(CUDA_INCLUDE) --ptxas-options=-v -Wno-deprecated-gpu-targets
+NVCCFLAGS = $(CUDA_INCLUDE) --ptxas-options=-v -O3 -Wno-deprecated-gpu-targets
 
 # generate code for supported compute capabilities
 # note: compute capability 1.x GPUs are no longer supported - use the '0.23' branch for older devices
@@ -36,7 +36,7 @@ NVCCFLAGS += --compiler-options=-Wall
 
 # Linker
 LD = gcc
-LDFLAGS = -fPIC $(CUDA_LIB) -lcudart_static -lm -lstdc++
+LDFLAGS = -flto -fPIC -Wl,--gc-sections $(CUDA_LIB) -lcudart_static -lm -lstdc++
 
 INSTALL = install
 

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -1,8 +1,8 @@
 CC = cl
-CFLAGS = /Ox /Oy /W2 /fp:fast /I"$(CUDA_PATH)\include" /I"$(CUDA_PATH)\include\cudart" /nologo
+CFLAGS = /O2 /Oy /W2 /fp:fast /I"$(CUDA_PATH)\include" /I"$(CUDA_PATH)\include\cudart" /nologo
 
-NVCCFLAGS = -m64 --ptxas-options=-v -Wno-deprecated-gpu-targets
-CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /Ox" $(NVCCFLAGS)
+NVCCFLAGS = -m64 -O3 --ptxas-options=-v -Wno-deprecated-gpu-targets
+CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /O2" $(NVCCFLAGS)
 
 ############################################################
 
@@ -52,10 +52,10 @@ clean :
 	$(CC) $(CFLAGS) /c /Tp $<
 
 tf_75bit.obj : tf_96bit.cu
-	nvcc -O2 -c $< -o $@ $(CUFLAGS) -DSHORTCUT_75BIT
+	nvcc -c $< -o $@ $(CUFLAGS) -DSHORTCUT_75BIT
 
 %.obj : %.cu
-	nvcc -O2 -c $< -o $@ $(CUFLAGS)
+	nvcc -c $< -o $@ $(CUFLAGS)
 
 ..\\%.ini : %.ini
 	$(INSTALL) $< ..


### PR DESCRIPTION
This changes the default compiler flags for better optimization.
I've been testing these for a while and haven't experienced any drawbacks, but factoring runs about ~1% faster for me. I mostly tested with the latest available CUDA versions, but it shouldn't break things with older ones.
So with this PR I suggest adding these flags to both Makefile and Makefile.win to make them the defaults.