### PR TITLE
Bump patchlevel to 0.24.0-beta.5

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -18,6 +18,8 @@ bug fixes:
 
 build:
 - made the build scripts more robust
+- more compiler optimizations enabled by default, slightly improving factoring
+  speed
 - new CUDA versions added to GitHub Actions workflow (thanks to NStorm)
 
 other changes:

--- a/src/params.h
+++ b/src/params.h
@@ -89,7 +89,7 @@ Otherwise, the automated builds could fail in GitHub Actions.
 Please discuss with the community before making changes to version numbers!
 */
 
-#define MFAKTC_VERSION            "0.24.0-beta.4"
+#define MFAKTC_VERSION            "0.24.0-beta.5"
 #define MFAKTC_CHECKPOINT_VERSION "0.24"
 #define MFAKTC_CHECKSUM_VERSION   1
 


### PR DESCRIPTION
I think it's time to push -beta.5 to make pre-release available on the "Releases" page.

This commit adds changelog entry on #f027b8f: more compiler optimizations enabled by default as well.

If I missed something that should be included on the changelog, please let me know or submit an edit.