### PR TITLE
mfaktc.ini sections

### DIFF
--- a/src/mfaktc.ini
+++ b/src/mfaktc.ini
@@ -1,34 +1,34 @@
-# SievePrimes defines how far the factor candidates (FCs) are pre-sieved on
-# the CPU. The first <SievePrimes> odd primes are used to sieve the FCs.
+##
+## User settings that should be modified:
+##
+
+# Prepend a user ID and computer name to each result in the results file,
+# similar to Prime95 and mprime. Both V5UserID and ComputerID must be set to
+# enable this feature.
 #
-# Minimum: SievePrimes=2000 (check SievePrimesMin)
-# Maximum: SievePrimes=200000
+# Default: none (unset)
 #
-# Default: SievePrimes=25000
+#V5UserID=<PrimeNet ID>
+#ComputerID=<hostname>
 
-SievePrimes=25000
-
-
-# Set this to 1 to enable automatic adjustments of SievePrimes during
-# runtime based on the "average wait times".
+# GPUSieveSize defines the size of the GPU sieve to use, in Mib.
+# Newer GPUs can get improved performance using a value of 2047
+# the default is set to 256 for maximum compatibility with old GPUs.
 #
-# Default: SievePrimesAdjust=1
-
-SievePrimesAdjust=1
-
-
-# Set the minimum and maximum limit for SievePrimes; this is needed if
-# SievePrimesAdjust is enabled. These are soft limits; there are hard limits
-# in the code which should never ever be changed.
+# Minimum: GPUSieveSize=4
+# Maximum: GPUSieveSize=2047
 #
-# Current limits are:
-# 2000 <= SievePrimesMin <= SievePrimes <= SievePrimesMax <= 200000
-#
-# Default: SievePrimesMin=5000
-#          SievePrimesMax=100000
+# Default: GPUSieveSize=256
 
-SievePrimesMin=5000
-SievePrimesMax=100000
+#GPUSieveSize=2047
+GPUSieveSize=256
+
+
+
+
+##
+## Other optional configuration settings:
+##
 
 
 # Set the number of CUDA streams / data sets.
@@ -129,7 +129,8 @@ Stages=0
 # 0: Do not stop the current assignment after a factor is found.
 # 1: Stop at the current bit level after finding a factor. Only makes sense
 #    when Stages is enabled.
-# 2: Stop at the current class after finding a factor
+# 2: Stop at the current class after finding a factor. Leaves bitlevel
+#    incomplete and may result in reduced GIMPS credit. Strongly discouraged.
 #
 # Default: StopAfterFactor=1
 
@@ -152,25 +153,6 @@ PrintMode=1
 # Default: Logging=0
 
 Logging=0
-
-
-# allow the CPU to sleep when idle?
-# 0: Do not sleep if the CPU must wait for the GPU
-# 1: The CPU can sleep for a short time
-#
-# Default: AllowSleep=0
-
-AllowSleep=0
-
-
-# Prepend a user ID and computer name to each result in the results file,
-# similar to Prime95 and mprime. Both V5UserID and ComputerID must be set to
-# enable this feature.
-#
-# Default: none (unset)
-#
-#V5UserID=<PrimeNet ID>
-#ComputerID=<hostname>
 
 
 # TimeStampInResults determines whether each line in the results file is
@@ -256,16 +238,6 @@ GPUSievePrimes=82486
 #GPUSievePrimes=8000
 
 
-# GPUSieveSize defines the size of the GPU sieve to use, in Mib.
-#
-# Minimum: GPUSieveSize=4
-#
-# Maximum: GPUSieveSize=2047
-#
-# Default: GPUSieveSize=256
-
-GPUSieveSize=256
-
 
 # GPUSieveProcessSize defines the size of the sieve each TF block
 # processes, in Kib. Larger values may lead to less wasted cycles by
@@ -280,3 +252,52 @@ GPUSieveSize=256
 # Default: GPUSieveProcessSize=16
 
 GPUSieveProcessSize=16
+
+
+
+
+##
+## Obsolete CPU-sieving configuration settings (may be removed in future versions)
+##
+
+
+# allow the CPU to sleep when idle?
+# 0: Do not sleep if the CPU must wait for the GPU
+# 1: The CPU can sleep for a short time
+#
+# Default: AllowSleep=0
+
+AllowSleep=1
+
+
+# SievePrimes defines how far the factor candidates (FCs) are pre-sieved on
+# the CPU. The first <SievePrimes> odd primes are used to sieve the FCs.
+#
+# Minimum: SievePrimes=2000 (check SievePrimesMin)
+# Maximum: SievePrimes=200000
+#
+# Default: SievePrimes=25000
+
+SievePrimes=25000
+
+
+# Set this to 1 to enable automatic adjustments of SievePrimes during
+# runtime based on the "average wait times".
+#
+# Default: SievePrimesAdjust=1
+
+SievePrimesAdjust=1
+
+
+# Set the minimum and maximum limit for SievePrimes; this is needed if
+# SievePrimesAdjust is enabled. These are soft limits; there are hard limits
+# in the code which should never ever be changed.
+#
+# Current limits are:
+# 2000 <= SievePrimesMin <= SievePrimes <= SievePrimesMax <= 200000
+#
+# Default: SievePrimesMin=5000
+#          SievePrimesMax=100000
+
+SievePrimesMin=5000
+SievePrimesMax=100000


### PR DESCRIPTION
Split mfaktc.ini into three logical sections:
* settings that the user should edit (e.g. UserID)
* normal configuration settings
* obsolete settings that may be removed in future versions (e.g. CPU-sieving settings)