### PR TITLE
Support builds with win-2022 & win-2025 due to win-2019 image deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Start Docker container
         run: |
           docker pull $CONTAINER
-          docker run --name build-container -d -v ${{ github.workspace }}:/workspace $CONTAINER tail -f /dev/null
+          docker run --name build-container -d -v ${GITHUB_WORKSPACE}:/workspace $CONTAINER tail -f /dev/null
 
       - name: Update GPG keys for CUDA repo on Ubuntu 16.04
         if: matrix.sys.ct_os == 'ubuntu16.04'
@@ -147,8 +147,8 @@ jobs:
         env:
           SCRIPT: |
             cd /workspace
-            zip -9 -j ${{ steps.prepare.outputs.BASE_NAME }}.zip *
-            echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
+            zip -9 -j ${{ steps.prepare.outputs.BASE_NAME }}.zip Changelog.txt COPYING mfaktc mfaktc.ini README.txt
+            echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
             ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
             ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
         run: docker exec build-container bash -c "$SCRIPT"
@@ -162,7 +162,9 @@ jobs:
 
 # Begin job "build-win"
   build-win:
-    runs-on: ${{ matrix.sys.os }}
+    # Build should work with windows-2022 images as well, but the resulting binaries
+    # are nearly identical. So let's target the image that will be supported longer term.
+    runs-on: windows-2025
 
     strategy:
       # If set to true, all jobs within the same matrix (such as Linux or
@@ -170,30 +172,35 @@ jobs:
       fail-fast: false
 
       matrix:
-        # Available versions can be viewed at the Jimver/cuda-toolkit action sources:
+        # Available CUDA versions can be viewed at the Jimver/cuda-toolkit action sources:
         # https://github.com/Jimver/cuda-toolkit/blob/v0.2.24/src/links/windows-links.ts
         sys:
-          - { cuda_version: '12.9.0', os: 'windows-2022' }
-          - { cuda_version: '12.8.1', os: 'windows-2022' }
-          - { cuda_version: '12.6.3', os: 'windows-2022' }
-          - { cuda_version: '12.5.1', os: 'windows-2022' }
-          - { cuda_version: '12.4.1', os: 'windows-2022' }
-          - { cuda_version: '12.3.2', os: 'windows-2022' }
-          - { cuda_version: '12.2.2', os: 'windows-2022' }
-          - { cuda_version: '12.1.1', os: 'windows-2022' }
-          - { cuda_version: '12.0.1', os: 'windows-2022' }
-          - { cuda_version: '11.8.0', os: 'windows-2022' }
-          - { cuda_version: '11.7.1', os: 'windows-2022' }
-          - { cuda_version: '11.6.2', os: 'windows-2022' }
-          - { cuda_version: '11.5.2', os: 'windows-2022' }
-          - { cuda_version: '11.4.4', os: 'windows-2022' }
-          - { cuda_version: '11.3.1', os: 'windows-2022' }
-          - { cuda_version: '11.2.2', os: 'windows-2019' }
-          - { cuda_version: '11.1.1', os: 'windows-2019' }
-          - { cuda_version: '11.0.1', os: 'windows-2019' }
-          - { cuda_version: '10.0.130', os: 'windows-2019' }
-          - { cuda_version: '9.2.148', os: 'windows-2019' }
-          - { cuda_version: '8.0.61', os: 'windows-2019' }
+          - { cuda_version: '12.9.0' }
+          - { cuda_version: '12.8.1' }
+          - { cuda_version: '12.6.3' }
+          - { cuda_version: '12.5.1' }
+          - { cuda_version: '12.4.1' }
+          - { cuda_version: '12.3.2' }
+          - { cuda_version: '12.2.2' }
+          - { cuda_version: '12.1.1' }
+          - { cuda_version: '12.0.1' }
+          - { cuda_version: '11.8.0' }
+          - { cuda_version: '11.7.1' }
+          - { cuda_version: '11.6.2' }
+          - { cuda_version: '11.5.2' }
+          - { cuda_version: '11.4.4' }
+          - { cuda_version: '11.3.1' }
+          - { cuda_version: '11.2.2' }
+          - { cuda_version: '11.1.1' }
+          - { cuda_version: '11.0.1' }
+          - { cuda_version: '10.0.130' }
+          - { cuda_version: '9.2.148' }
+          - { cuda_version: '8.0.61' }
+
+    env:
+      MSVC_PKG_VC140: Microsoft.VisualStudio.Component.VC.140
+      MSVC_PKG_VC141: Microsoft.VisualStudio.Component.VC.v141.x86.x64
+      MSVC_SETUP_CMD: '"C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe" modify --passive --norestart --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"'
 
     steps:
 
@@ -224,41 +231,43 @@ jobs:
           bash .github/workflows/scripts/build_helper.sh ${{ matrix.sys.cuda_version }}
           cat .github/workflows/scripts/build_helper.sh.out >> $GITHUB_OUTPUT
 
-      - name: Build from sources with MSVC 2022 using PowerShell
-        if: ${{ matrix.sys.os == 'windows-2022' }}
-        shell: powershell
-        # MSVC 2022 on the Windows 2022 Server runner has a PowerShell script to
-        # launch a development shell.
-        run: |
-          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' -Arch amd64 -HostArch amd64
-          cd "${{ github.workspace }}\src"
-          Copy-Item mfaktc.ini ..
-          make SHELL="powershell.exe" -f Makefile.win
-
-      - name: Build from sources with MSVC 2019 using cmd.exe
-        if: ${{ matrix.sys.os == 'windows-2019' }}
+      - name: Build from sources with MSVC
         shell: cmd
-        # MSVC 2019 has a similar script on the Windows 2019 Server runner, but
-        # that only supports a 32-bit (x86) environment and doesn't allow
-        # setting the architecture.
-        # So we have to run a batch file to configure a 64-bit environment and
-        # then launch PowerShell from make afterwards. PowerShell is much better
-        # at handling long paths and quotes when invoked from make.
         run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" x64 ${{ env.VCVARS_VER }} & cd src & copy mfaktc.ini .. & make SHELL="powershell.exe" -f Makefile.win
+          ${{ env.MSVC_ADD_PKG_CMD }}
+          "${{ env.VCVARS_PATH }}" x64 ${{ env.VCVARS_VER }} & cd src & copy mfaktc.ini .. & make SHELL="powershell.exe" -j%NUMBER_OF_PROCESSORS% -f Makefile.win & cl /? 2>&1 | findstr /C:"Version" > clversion.log & echo Build finished
         env:
-          # -vcvars_ver=14.0 enables the MSVC 14.0 (2015) build environment -
-          # this is an MSVC 2019 component and not a complete MSVC instance.
-          VCVARS_VER: ${{ steps.prepare.outputs.CUDA_VER_MAJOR <= 10 && '-vcvars_ver=14.0' || '' }}
+          VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+          # vcvars_ver=14.X enables previous versions of MSVC build environments (MSVC 2015: 14.0, MSVC 2017: 14.16, MSVC 2019: 14.29)
+          VCVARS_VER: >-
+            ${{ (
+                 steps.prepare.outputs.CUDA_VER_MAJOR <= 9 && '-vcvars_ver=14.0'
+              || steps.prepare.outputs.CUDA_VER_MAJOR == 10 && '-vcvars_ver=14.16'
+              || steps.prepare.outputs.CUDA_VER_MAJOR == 11 && steps.prepare.outputs.CUDA_VER_MINOR <= 2 && '-vcvars_ver=14.29'
+              || ''
+            ) }}
+          # windows-2022/2025 images come with the MSVC 2019 component (named VC142 internally) installed,
+          # but older versions need to be installed by running '${MSVC_SETUP_CMD} --add PKG_NAME'
+          # ${MSVC_PKG_VC140} is required for 14.0 (MSVC 2015), and ${MSVC_PKG_VC141} for 14.16 (MSVC 2017)
+          MSVC_ADD_PKG_CMD: >-
+            ${{ (
+                 steps.prepare.outputs.CUDA_VER_MAJOR <= 9 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC140)
+              || steps.prepare.outputs.CUDA_VER_MAJOR == 10 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC141)
+              || 'REM No component to install'
+            ) }}
 
       - name: Prepare build archive with description
         shell: bash
+        # We can't get the actual compiler (cl.exe) version in the helper script, because it might not be installed during the 'prepare' stage.
+        # COMPILER_VER from that stage contains the MSVC version, but not the compiler version, which has its own version number.
+        # So a little hack was added to log the cl version during the build stage, and now we extract and use it in the report along with the MSVC version.
         run: |
-          choco install -y --no-progress zip
-          zip -9 -j "${{ steps.prepare.outputs.BASE_NAME }}.zip" *
-          echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
+          [ -f src/clversion.log ] && CL_VER="$(grep -Eoe 'Version [\.0-9]+ ' src/clversion.log | cut -d' ' -f2)"
+          [ -z "$CL_VER" ] && CL_VER='Unknown'
+          tar -a -c -f "${{ steps.prepare.outputs.BASE_NAME }}.zip" Changelog.txt COPYING mfaktc-win-64.exe mfaktc.ini README.txt
+          echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
           ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
-          ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
+          ${CL_VER} (${{ steps.prepare.outputs.COMPILER_VER }}) | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -291,8 +300,8 @@ jobs:
       - name: Prepare asset list and release notes
         id: makeinfo
         run: |
-          if ! compgen -G "${{ env.base_name }}.txt" > /dev/null 2>&1; then
-            echo "::error ::Could not find release notes with mask ${{ env.base_name }}.txt"
+          if ! compgen -G "${base_name}.txt" > /dev/null 2>&1; then
+            echo "::error ::Could not find release notes with mask ${base_name}.txt"
             echo "::error ::Ensure the Git tag name begins with the version specified by MFAKTC_VERSION in src/params.h"
             exit 1
           fi
@@ -303,14 +312,14 @@ jobs:
             echo
             echo "File | CUDA version | Compute Capability | Build OS | Compiler version | NVCC version"
             echo "--- | --- | --- | --- | --- | ---"
-            sort -Vr ${{ env.base_name }}.txt
+            sort -Vr ${base_name}.txt
           } > RELEASE_NOTES.txt
           {
             echo 'RELEASE_FILES<<EOF'
-            printf '%s\n' ${{ env.base_name }}.zip | sort -Vr
+            printf '%s\n' "${base_name}.zip" | sort -Vr
             echo 'EOF'
           } > $GITHUB_OUTPUT
-          ( echo "${{ github.ref_name }}" | grep -qsP "v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(-(?:alpha|beta|pre))" && echo "PRERELEASE=true" || echo "PRERELEASE=false" ) >> $GITHUB_OUTPUT
+          ( echo "$GITHUB_REF_NAME" | grep -qsP "v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(-(?:alpha|beta|pre))" && echo "PRERELEASE=true" || echo "PRERELEASE=false" ) >> $GITHUB_OUTPUT
 
       - name: Create and upload release package
         uses: softprops/action-gh-release@v2.2.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,99 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '16 12 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: 'ubuntu-latest'
+    container: 'nvcr.io/nvidia/cuda:12.9.0-devel-ubuntu24.04'
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: c-cpp
+          build-mode: autobuild
+        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Add any setup steps before running the `github/codeql-action/init` action.
+    # This includes steps like installing compilers or runtimes (`actions/setup-node`
+    # or others). This is typically only required for manual builds.
+    # - name: Setup runtime (example)
+    #   uses: actions/setup-example@v1
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
These changes affect only the CI/CD workflows on GitHub, almost exclusively the Windows builds. No changes were made to the mfaktc code.

- Migrate builds for older CUDA versions to newer Windows images due to the upcoming deprecation of the windows-2019 image. Install previous build environments as MSVC 2022 packages when required, and use them when the CUDA version demands it.
- Replace two separate build steps for PowerShell and cmd.exe with a single universal step capable of handling all build variants via conditional parameters.
- Support builds with windows-2022 and windows-2025 images for any CUDA ver.
- Retrieve the MSVC compiler (`cl.exe`) version during the build step (it differs from the MSVC product version) and add it to the release table along with the MSVC version to distinguish the build environment used.
- Filter and replace repetitive info in the release table with shorter terms to make it slightly more compact.
- Use environment variables instead of substitutions in code run steps, which should be safer.
- Use undocumented `-a` option of the `tar` command bundled with Windows to create zip archives instead of installing Info-ZIP from Chocolatey.
- Minor fixes and improvements for the CI/CD workflow in general.
- Add CodeQL analysis workflow for security scanning.