### PR TITLE
Implement print_dez96(), use macros for magic numbers

### DIFF
--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -35,9 +35,6 @@ checkpoint_write() writes the checkpoint file.
 */
 {
     FILE *f;
-    const int MAX_FACTOR_BUFFER_LENGTH       = MAX_FACTORS_PER_JOB * MAX_DEZ_96_STRING_LENGTH;
-    const int MAX_BUFFER_LENGTH              = MAX_FACTOR_BUFFER_LENGTH + 100;
-    const int MAX_CHECKPOINT_FILENAME_LENGTH = 40;
     char buffer[MAX_BUFFER_LENGTH], filename[MAX_CHECKPOINT_FILENAME_LENGTH], factors_buffer[MAX_FACTOR_BUFFER_LENGTH];
     unsigned int i, factors_buffer_length;
 

--- a/src/output.c
+++ b/src/output.c
@@ -99,32 +99,42 @@ Enough space is
 
 void print_dez96(int96 a, char *buf)
 {
-    int192 tmp;
+    char digit[MAX_DEZ_96_STRING_LENGTH];
+    int digits = 0, carry = 0, i = 0;
+    long long int tmp = 0;
 
-    tmp.d5 = 0;
-    tmp.d4 = 0;
-    tmp.d3 = 0;
-    tmp.d2 = a.d2;
-    tmp.d1 = a.d1;
-    tmp.d0 = a.d0;
-
-    print_dez192(tmp, buf);
+    // clang-format off
+    while((a.d0 !=0 || a.d1 !=0 || a.d2 !=0) && digits < (MAX_DEZ_96_STRING_LENGTH - 1)) {
+                                                       carry = a.d2 % 10; a.d2 /=      10;
+        tmp = a.d1; tmp += (long long int)carry << 32; carry = tmp  % 10; a.d1 = tmp / 10;
+        tmp = a.d0; tmp += (long long int)carry << 32; carry = tmp  % 10; a.d0 = tmp / 10;
+        digit[digits++] = carry;
+    }
+    // clang-format on
+    if (digits == 0)
+        sprintf(buf, "0");
+    else {
+        digits--;
+        while (digits >= 0) {
+            sprintf(&(buf[i++]), "%1d", digit[digits--]);
+        }
+    }
 }
 
 void print_dez192(int192 a, char *buf)
 {
-    char digit[58];
+    char digit[MAX_DEZ_192_STRING_LENGTH];
     int digits = 0, carry, i = 0;
     long long int tmp;
 
     // clang-format off
-    while ((a.d0 != 0 || a.d1 != 0 || a.d2 != 0 || a.d3 != 0 || a.d4 != 0 || a.d5 != 0) && digits < 58) {
-        carry = a.d5 % 10; a.d5 /= 10;
-        tmp = a.d4; tmp += (long long int)carry << 32; carry = tmp % 10;  a.d4 = tmp / 10;
-        tmp = a.d3; tmp += (long long int)carry << 32; carry = tmp % 10;  a.d3 = tmp / 10;
-        tmp = a.d2; tmp += (long long int)carry << 32; carry = tmp % 10;  a.d2 = tmp / 10;
-        tmp = a.d1; tmp += (long long int)carry << 32; carry = tmp % 10;  a.d1 = tmp / 10;
-        tmp = a.d0; tmp += (long long int)carry << 32; carry = tmp % 10;  a.d0 = tmp / 10;
+    while ((a.d0 != 0 || a.d1 != 0 || a.d2 != 0 || a.d3 != 0 || a.d4 != 0 || a.d5 != 0) && digits < (MAX_DEZ_192_STRING_LENGTH - 1)) {
+                                                       carry = a.d5 % 10; a.d5 /=      10;
+        tmp = a.d4; tmp += (long long int)carry << 32; carry = tmp  % 10; a.d4 = tmp / 10;
+        tmp = a.d3; tmp += (long long int)carry << 32; carry = tmp  % 10; a.d3 = tmp / 10;
+        tmp = a.d2; tmp += (long long int)carry << 32; carry = tmp  % 10; a.d2 = tmp / 10;
+        tmp = a.d1; tmp += (long long int)carry << 32; carry = tmp  % 10; a.d1 = tmp / 10;
+        tmp = a.d0; tmp += (long long int)carry << 32; carry = tmp  % 10; a.d0 = tmp / 10;
         digit[digits++] = carry;
     }
     // clang-format on
@@ -624,15 +634,15 @@ example using M50,000,000 from 2^69-2^70:
     bit_min++;
 
     while (bit_min <= bit_max && bit_min <= 62) {
-        ghzdays += 0.011160 * pow(2.0, (double)bit_min - 48.0);
+        ghzdays += GHZDAYS_MAGIC_TF_BOT * pow(2.0, (double)bit_min - 48.0);
         bit_min++;
     }
     while (bit_min <= bit_max && bit_min <= 64) {
-        ghzdays += 0.017832 * pow(2.0, (double)bit_min - 48.0);
+        ghzdays += GHZDAYS_MAGIC_TF_MID * pow(2.0, (double)bit_min - 48.0);
         bit_min++;
     }
     while (bit_min <= bit_max) {
-        ghzdays += 0.016968 * pow(2.0, (double)bit_min - 48.0);
+        ghzdays += GHZDAYS_MAGIC_TF_TOP * pow(2.0, (double)bit_min - 48.0);
         bit_min++;
     }
 

--- a/src/params.h
+++ b/src/params.h
@@ -188,7 +188,16 @@ The following lines define the min, default and max value.
 #endif
 
 /* For worktodo.txt files */
-#define MAX_LINE_LENGTH          100
+#define MAX_LINE_LENGTH                100
 
-#define MAX_FACTORS_PER_JOB      20
-#define MAX_DEZ_96_STRING_LENGTH 30
+#define MAX_FACTORS_PER_JOB            20
+#define MAX_DEZ_96_STRING_LENGTH       30 // max value of int96 (unsigned) has 29 digits + 1 byte for NUL
+#define MAX_DEZ_192_STRING_LENGTH      59 // max value of int192 (unsigned) has 58 digits + 1 byte for NUL
+
+#define MAX_FACTOR_BUFFER_LENGTH       (MAX_FACTORS_PER_JOB * MAX_DEZ_96_STRING_LENGTH)
+#define MAX_BUFFER_LENGTH              (MAX_FACTOR_BUFFER_LENGTH + 100)
+#define MAX_CHECKPOINT_FILENAME_LENGTH 40
+
+#define GHZDAYS_MAGIC_TF_TOP           0.016968 // magic constant for TF to 65-bit and above
+#define GHZDAYS_MAGIC_TF_MID           0.017832 // magic constant for 63-and 64-bit
+#define GHZDAYS_MAGIC_TF_BOT           0.011160 // magic constant for 62-bit and below


### PR DESCRIPTION
print_dez96() previously was a stub calling print_dez192 with 96 high bits set to 0.
This PR implements print_dez96() to work with int96 directly, saving some cycles by avoiding unnecessary calculations.
A few constants were migrated to macros instead of being hardcoded in place.
