### PR TITLE
Disambiguate release information

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,7 +268,7 @@ jobs:
             ${{ (
                  steps.prepare.outputs.CUDA_VER_MAJOR <= 9 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC140)
               || steps.prepare.outputs.CUDA_VER_MAJOR == 10 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC141)
-              || 'echo Build Tools for Visual Studio 2019 already exist - installation not needed'
+              || 'echo Build Tools already exist - installation not needed'
             ) }}
 
       - name: Prepare build archive with description

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,7 +268,7 @@ jobs:
             ${{ (
                  steps.prepare.outputs.CUDA_VER_MAJOR <= 9 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC140)
               || steps.prepare.outputs.CUDA_VER_MAJOR == 10 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC141)
-              || 'REM Build Tools for Visual Studio 2019 already exist - no additional component to install'
+              || 'echo Build Tools for Visual Studio 2019 already exist - installation not needed'
             ) }}
 
       - name: Prepare build archive with description

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,8 +168,9 @@ jobs:
 
 # Begin job "build-win"
   build-win:
-    # Build should work with windows-2022 images as well, but the resulting binaries
-    # are nearly identical. So let's target the image that will be supported longer term.
+    # windows-2022 also works and produces nearly identical binaries, so let's
+    # target the image that will be supported in the longer term. windows-2025
+    # is in beta as of June 2025, but testing has shown it is reliable.
     runs-on: windows-2025
 
     strategy:
@@ -244,7 +245,10 @@ jobs:
           "${{ env.VCVARS_PATH }}" x64 ${{ env.VCVARS_VER }} & cd src & copy mfaktc.ini .. & make SHELL="powershell.exe" -j%NUMBER_OF_PROCESSORS% -f Makefile.win & cl /? 2>&1 | findstr /C:"Version" > clversion.log & echo Build finished
         env:
           VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
-          # vcvars_ver=14.X enables previous versions of MSVC build environments (MSVC 2015: 14.0, MSVC 2017: 14.16, MSVC 2019: 14.29)
+          # vcvars_ver=14.x enables Build Tools for previous MSVC versions:
+          # - 14.0 is for Visual Studio 2015
+          # - 14.16 is for Visual Studio 2017 version 15.9.x
+          # - 14.29 is for Visual Studio 2019 version 16.11.x
           VCVARS_VER: >-
             ${{ (
                  steps.prepare.outputs.CUDA_VER_MAJOR <= 9 && '-vcvars_ver=14.0'
@@ -252,21 +256,27 @@ jobs:
               || steps.prepare.outputs.CUDA_VER_MAJOR == 11 && steps.prepare.outputs.CUDA_VER_MINOR <= 2 && '-vcvars_ver=14.29'
               || ''
             ) }}
-          # windows-2022/2025 images come with the MSVC 2019 component (named VC142 internally) installed,
-          # but older versions need to be installed by running '${MSVC_SETUP_CMD} --add PKG_NAME'
-          # ${MSVC_PKG_VC140} is required for 14.0 (MSVC 2015), and ${MSVC_PKG_VC141} for 14.16 (MSVC 2017)
+          # Build Tools for Visual Studio 2019 (named VC142 internally) are
+          # included with windows-2022 and later. However, the Build Tools for
+          # older MSVC versions need to be installed by running '${MSVC_SETUP_CMD} --add <package name>'
+          #
+          # - ${MSVC_PKG_VC140} is required for 14.0 / MSVC 2015
+          # - ${MSVC_PKG_VC141} is required for 14.16 / MSVC 2017 version 15.9.x
           MSVC_ADD_PKG_CMD: >-
             ${{ (
                  steps.prepare.outputs.CUDA_VER_MAJOR <= 9 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC140)
               || steps.prepare.outputs.CUDA_VER_MAJOR == 10 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC141)
-              || 'REM No component to install'
+              || 'REM Build Tools for Visual Studio 2019 already exist - no additional component to install'
             ) }}
 
       - name: Prepare build archive with description
         shell: bash
-        # We can't get the actual compiler (cl.exe) version in the helper script, because it might not be installed during the 'prepare' stage.
-        # COMPILER_VER from that stage contains the MSVC version, but not the compiler version, which has its own version number.
-        # So a little hack was added to log the cl version during the build stage, and now we extract and use it in the report along with the MSVC version.
+        # We can't get the actual compiler (cl.exe) version with the helper
+        # script because cl might not be installed during the 'Prepare sources
+        # and gather info' step. COMPILER_VER is set to the MSVC rather than
+        # the cl version number, so we added a hack to log the cl version
+        # during the build step. Here, the cl version is extracted and added to
+        # the table along with the MSVC version.
         run: |
           [ -f src/clversion.log ] && CL_VER="$(grep -Eoe 'Version [\.0-9]+ ' src/clversion.log | cut -d' ' -f2)"
           [ -z "$CL_VER" ] && CL_VER='Unknown'
@@ -290,10 +300,8 @@ jobs:
 
 # Begin job "upload-release"
   upload-release:
-    # This job expects the Git tag name to begin with the version specified by
-    # MFAKTC_VERSION in params.h
-    # Otherwise, the job will fail because there is a version conflict between Git
-    # and params.h that must be resolved.
+    # Git tag name must begin with the version specified by MFAKTC_VERSION in
+    # params.h or else the job will fail
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/')
     needs: [ build-linux, build-win ]
     runs-on: ubuntu-latest
@@ -318,7 +326,7 @@ jobs:
             exit 1
           fi
           {
-            echo "Binary releases (automated builds) as follows."
+            echo "Pre-compiled binaries (automated builds) as follows."
             echo "In this table, the Compute Capability column means the minimum and maximum versions supported."
             echo
             echo "File | CUDA version | Compute Capability | Build OS | Host compiler | NVCC version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,8 +148,14 @@ jobs:
           SCRIPT: |
             cd /workspace
             zip -9 -j ${{ steps.prepare.outputs.BASE_NAME }}.zip Changelog.txt COPYING mfaktc mfaktc.ini README.txt
+            cc_min=${{ steps.prepare.outputs.CC_MIN }}
+            cc_max=${{ steps.prepare.outputs.CC_MAX }}
+            cc_min_minor=$(($cc_min % 10))
+            cc_min_major=$((($cc_min - $cc_min_minor) / 10))
+            cc_max_minor=$(($cc_max % 10))
+            cc_max_major=$((($cc_max - $cc_max_minor) / 10))
             echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
-            ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
+            ${{ matrix.sys.cuda_version }} | $cc_min_major.$cc_min_minor-$cc_max_major.$cc_max_minor | ${{ steps.prepare.outputs.OS_VER }} | \
             ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
         run: docker exec build-container bash -c "$SCRIPT"
 
@@ -265,8 +271,14 @@ jobs:
           [ -f src/clversion.log ] && CL_VER="$(grep -Eoe 'Version [\.0-9]+ ' src/clversion.log | cut -d' ' -f2)"
           [ -z "$CL_VER" ] && CL_VER='Unknown'
           tar -a -c -f "${{ steps.prepare.outputs.BASE_NAME }}.zip" Changelog.txt COPYING mfaktc-win-64.exe mfaktc.ini README.txt
+          cc_min=${{ steps.prepare.outputs.CC_MIN }}
+          cc_max=${{ steps.prepare.outputs.CC_MAX }}
+          cc_min_minor=$(($cc_min % 10))
+          cc_min_major=$((($cc_min - $cc_min_minor) / 10))
+          cc_max_minor=$(($cc_max % 10))
+          cc_max_major=$((($cc_max - $cc_max_minor) / 10))
           echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
-          ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
+          ${{ matrix.sys.cuda_version }} | $cc_min_major.$cc_min_minor-$cc_max_major.$cc_max_minor | ${{ steps.prepare.outputs.OS_VER }} | \
           ${CL_VER} (${{ steps.prepare.outputs.COMPILER_VER }}) | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
 
       - name: Upload build artifacts
@@ -307,10 +319,9 @@ jobs:
           fi
           {
             echo "Binary releases (automated builds) as follows."
-            echo "Compute Capability (CC) in the table means minimum and maximum versions supported."
-            echo "CC versions are listed without the separator. For example, '90' means devices with compute capability 9.0 can run that build."
+            echo "In this table, the Compute Capability column means the minimum and maximum versions supported."
             echo
-            echo "File | CUDA version | Compute Capability | Build OS | Compiler version | NVCC version"
+            echo "File | CUDA version | Compute Capability | Build OS | Host compiler | NVCC version"
             echo "--- | --- | --- | --- | --- | ---"
             sort -Vr ${base_name}.txt
           } > RELEASE_NOTES.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,13 @@ on:
   push:
     paths-ignore:
       - '**/*.txt'
+      - '**/*.ini'
       - 'COPYING'
       - '.gitignore'
   pull_request:
     paths-ignore:
       - '**/*.txt'
+      - '**/*.ini'
       - 'COPYING'
       - '.gitignore'
     types:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,14 +150,8 @@ jobs:
           SCRIPT: |
             cd /workspace
             zip -9 -j ${{ steps.prepare.outputs.BASE_NAME }}.zip Changelog.txt COPYING mfaktc mfaktc.ini README.txt
-            cc_min=${{ steps.prepare.outputs.CC_MIN }}
-            cc_max=${{ steps.prepare.outputs.CC_MAX }}
-            cc_min_minor=$(($cc_min % 10))
-            cc_min_major=$((($cc_min - $cc_min_minor) / 10))
-            cc_max_minor=$(($cc_max % 10))
-            cc_max_major=$((($cc_max - $cc_max_minor) / 10))
             echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
-            ${{ matrix.sys.cuda_version }} | $cc_min_major.$cc_min_minor-$cc_max_major.$cc_max_minor | ${{ steps.prepare.outputs.OS_VER }} | \
+            ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
             ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
         run: docker exec build-container bash -c "$SCRIPT"
 
@@ -283,14 +277,8 @@ jobs:
           [ -f src/clversion.log ] && CL_VER="$(grep -Eoe 'Version [\.0-9]+ ' src/clversion.log | cut -d' ' -f2)"
           [ -z "$CL_VER" ] && CL_VER='Unknown'
           tar -a -c -f "${{ steps.prepare.outputs.BASE_NAME }}.zip" Changelog.txt COPYING mfaktc-win-64.exe mfaktc.ini README.txt
-          cc_min=${{ steps.prepare.outputs.CC_MIN }}
-          cc_max=${{ steps.prepare.outputs.CC_MAX }}
-          cc_min_minor=$(($cc_min % 10))
-          cc_min_major=$((($cc_min - $cc_min_minor) / 10))
-          cc_max_minor=$(($cc_max % 10))
-          cc_max_major=$((($cc_max - $cc_max_minor) / 10))
           echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
-          ${{ matrix.sys.cuda_version }} | $cc_min_major.$cc_min_minor-$cc_max_major.$cc_max_minor | ${{ steps.prepare.outputs.OS_VER }} | \
+          ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
           ${CL_VER} (${{ steps.prepare.outputs.COMPILER_VER }}) | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
 
       - name: Upload build artifacts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,15 +1,4 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL Advanced"
+name: "CodeQL (advanced setup)"
 
 on:
   push:
@@ -22,11 +11,6 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: 'ubuntu-latest'
     container: 'nvcr.io/nvidia/cuda:12.9.0-devel-ubuntu24.04'
     permissions:
@@ -46,54 +30,17 @@ jobs:
         include:
         - language: c-cpp
           build-mode: autobuild
-        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
-
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
-    - name: Perform CodeQL Analysis
+    - name: Perform CodeQL analysis
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/scripts/build_helper.sh
+++ b/.github/workflows/scripts/build_helper.sh
@@ -69,8 +69,10 @@ elif [ ${#CC_LIST[*]} -lt 3 ]; then
   echo "Warning: less than three (3) supported compute capabilities" >&2
 fi
 
-echo "All supported CCs: ${CC_LIST[*]}, CC_MIN=${CC_LIST[0]}, CC_MAX=${CC_LIST[-1]}"
-echo -e "CC_LIST=\"${CC_LIST[*]}\"\nCC_MIN=${CC_LIST[0]}\nCC_MAX=${CC_LIST[-1]}" >> "$0.out"
+CC_MIN="${CC_LIST[0]:0:(-1)}.${CC_LIST[0]:(-1)}"
+CC_MAX="${CC_LIST[-1]:0:(-1)}.${CC_LIST[-1]:(-1)}"
+echo "All supported CCs: ${CC_LIST[*]}, CC_MIN=${CC_MIN}, CC_MAX=${CC_MAX}"
+echo -e "CC_LIST=\"${CC_LIST[*]}\"\nCC_MIN=${CC_MIN}\nCC_MAX=${CC_MAX}" >> "$0.out"
 
 echo 'Removing NVCCFLAGS strings with "arch=..." entries from makefiles and populating them with discovered supported values.'
 sed -i '/^NVCCFLAGS += --generate-code arch=compute.*/d' src/Makefile.win src/Makefile

--- a/.github/workflows/scripts/build_helper.sh
+++ b/.github/workflows/scripts/build_helper.sh
@@ -87,9 +87,9 @@ if [ "$CUDA_VER" -lt 1200 ]; then
   sed -i -E 's/^(LDFLAGS = .*? -lcudart_static) (.*)/\1 -ldl -lrt -lpthread \2/' src/Makefile
 fi
 
-echo 'Gathering version info on generic compiler and NVCC...'
+echo 'Gathering host compiler and NVCC version info...'
 # COMPILER_VER for Windows builds is actually set to the MSVC product version.
-# The workflow retrieves the version from cl.exe during the build stage and adds it to the report.
+# We retrieve the cl.exe version during the build step and add it to the table.
 if [[ -x "$(command -v vswhere.exe)" ]]; then
   CC_VSPROD="$(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property displayName | sed -e 's/Visual Studio/MSVC/')"
   COMPILER_VER="${CC_VSPROD}, $(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion)"

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -18,9 +18,12 @@ bug fixes:
 
 build:
 - made the build scripts more robust
-- more compiler optimizations enabled by default, slightly improving factoring
-  speed
-- new CUDA versions added to GitHub Actions workflow (thanks to NStorm)
+- enabled more compiler optimizations by default for a slight performance gain
+  (thanks to NStorm)
+- various improvements to GitHub Actions workflows (thanks to NStorm)
+  - support for additional CUDA versions
+  - removed dependency on deprecated windows-2019 images
+  - code analysis with CodeQL
 
 other changes:
 - dropped support for compute capability 1.x and 32-bit builds

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -36,6 +36,7 @@ other changes:
   - please use results.json.txt for submissions
   - set LegacyResultsTxt=1 in mfaktc.ini to restore old behavior and re-enable
     logging to results.txt
+- re-organized mfaktc.ini to be more user-friendly (thanks to James Heinrich)
 
 version 0.23.4
 ==============================

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -24,6 +24,8 @@ build:
   - support for additional CUDA versions
   - removed dependency on deprecated windows-2019 images
   - code analysis with CodeQL
+- improved visual appearance and clarity of release information (thanks to
+  Danny Chia)
 
 other changes:
 - dropped support for compute capability 1.x and 32-bit builds

--- a/src/mfaktc.ini
+++ b/src/mfaktc.ini
@@ -262,7 +262,7 @@ GPUSieveProcessSize=16
 # 0: Disable CPU sleep
 # 1: Enable CPU sleep
 #
-# Default: AllowSleep=1
+# Default: AllowSleep=0
 
 AllowSleep=1
 

--- a/src/mfaktc.ini
+++ b/src/mfaktc.ini
@@ -1,5 +1,5 @@
 ##
-## User settings that should be modified:
+## User settings that are commonly modified:
 ##
 
 # Prepend a user ID and computer name to each result in the results file,
@@ -12,8 +12,8 @@
 #ComputerID=<hostname>
 
 # GPUSieveSize defines the size of the GPU sieve to use, in Mib.
-# Newer GPUs can get improved performance using a value of 2047
-# the default is set to 256 for maximum compatibility with old GPUs.
+# Default is set to 256 for maximum compatibility and to avoid issues on older
+# devices. Using a value of 2047 can give better performance on newer GPUs.
 #
 # Minimum: GPUSieveSize=4
 # Maximum: GPUSieveSize=2047
@@ -22,8 +22,6 @@
 
 #GPUSieveSize=2047
 GPUSieveSize=256
-
-
 
 
 ##
@@ -129,8 +127,9 @@ Stages=0
 # 0: Do not stop the current assignment after a factor is found.
 # 1: Stop at the current bit level after finding a factor. Only makes sense
 #    when Stages is enabled.
-# 2: Stop at the current class after finding a factor. Leaves bitlevel
-#    incomplete and may result in reduced GIMPS credit. Strongly discouraged.
+# 2: Stop at the current class after finding a factor. Leaves bit level
+#    incomplete and may result in reduced GIMPS credit depending on factor
+#    size. Strongly discouraged.
 #
 # Default: StopAfterFactor=1
 
@@ -238,7 +237,6 @@ GPUSievePrimes=82486
 #GPUSievePrimes=8000
 
 
-
 # GPUSieveProcessSize defines the size of the sieve each TF block
 # processes, in Kib. Larger values may lead to less wasted cycles by
 # reducing how often the threads in a warp are idle. However, this may reduce
@@ -254,18 +252,17 @@ GPUSievePrimes=82486
 GPUSieveProcessSize=16
 
 
-
-
 ##
-## Obsolete CPU-sieving configuration settings (may be removed in future versions)
+## CPU sieving settings (obsolete and may be removed in the future)
 ##
 
 
-# allow the CPU to sleep when idle?
-# 0: Do not sleep if the CPU must wait for the GPU
-# 1: The CPU can sleep for a short time
+# Sets whether to allow the CPU to sleep for a short time when idle; this
+# usually happens when the CPU has to wait for the GPU.
+# 0: Disable CPU sleep
+# 1: Enable CPU sleep
 #
-# Default: AllowSleep=0
+# Default: AllowSleep=1
 
 AllowSleep=1
 
@@ -282,7 +279,7 @@ SievePrimes=25000
 
 
 # Set this to 1 to enable automatic adjustments of SievePrimes during
-# runtime based on the "average wait times".
+# runtime based on the "average CPU wait"
 #
 # Default: SievePrimesAdjust=1
 
@@ -290,8 +287,8 @@ SievePrimesAdjust=1
 
 
 # Set the minimum and maximum limit for SievePrimes; this is needed if
-# SievePrimesAdjust is enabled. These are soft limits; there are hard limits
-# in the code which should never ever be changed.
+# SievePrimesAdjust is enabled. Configured values are soft limits; there are
+# hard limits in the code which should never ever be changed.
 #
 # Current limits are:
 # 2000 <= SievePrimesMin <= SievePrimes <= SievePrimesMax <= 200000


### PR DESCRIPTION
This PR adds changes to make the release information less ambiguous:
* CC versions in the build table now correctly contain the separator (so no more wondering whether `120` refers to 12.0 or 1.20)
* changed mentions of generic compilers to "host compiler" (as both `cl.exe` and NVCC are compilers)

Additional changes:
* made comments in the build script and workflow config more human-readable
  * clarified which MSVC versions `vcvars_ver` refers to. For example, 14.16 is only for Visual Studio 2017 version 15.9.x as opposed to MSVC 2017 as a whole
* removed unused auto-generated stuff in `CodeQL.yml`
* excluded INI files for now as the workflow does not run mfaktc