### PR TITLE
Add Blackwell support to Makefile.win

### DIFF
--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -18,6 +18,7 @@ NVCCFLAGS += --generate-code arch=compute_86,code=sm_86
 NVCCFLAGS += --generate-code arch=compute_87,code=sm_87
 NVCCFLAGS += --generate-code arch=compute_89,code=sm_89
 NVCCFLAGS += --generate-code arch=compute_90,code=sm_90
+NVCCFLAGS += --generate-code arch=compute_120,code=sm_120
 
 ############################################################
 


### PR DESCRIPTION
A line was missing from Makefile.win to add Blackwell support, so compiling on RTX 50 series GPUs on Windows didn't go correctly.