### PR TITLE
Backport changes to 0.23 branch and bump to version 0.23.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ jobs:
         sys:
           # Specified version combination must exist as CUDA container image from Nvidia: nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}
           # Available versions can be found here: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags (note that only Ubuntu distros are supported by this action)
+          - { cuda_version: '12.9.0', ct_os: 'ubuntu24.04' }
           - { cuda_version: '12.8.1', ct_os: 'ubuntu24.04' }
           # - { cuda_version: '12.8.0', ct_os: 'ubuntu24.04' }
           - { cuda_version: '12.6.3', ct_os: 'ubuntu22.04' }
@@ -172,6 +173,7 @@ jobs:
         # Available versions can be viewed at the Jimver/cuda-toolkit action sources:
         # https://github.com/Jimver/cuda-toolkit/blob/v0.2.21/src/links/windows-links.ts
         sys:
+          - { cuda_version: '12.9.0', os: 'windows-2022' }
           - { cuda_version: '12.8.1', os: 'windows-2022' }
           - { cuda_version: '12.6.3', os: 'windows-2022' }
           - { cuda_version: '12.5.1', os: 'windows-2022' }
@@ -203,7 +205,7 @@ jobs:
 
       - name: Install CUDA Toolkit
         id: cuda-toolkit
-        uses: Jimver/cuda-toolkit@v0.2.22
+        uses: Jimver/cuda-toolkit@v0.2.24
         with:
           cuda: ${{ matrix.sys.cuda_version }}
           sub-packages: ${{ startsWith(matrix.sys.cuda_version, '8.') && '[]' || '[ "nvcc", "cudart" ]' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,13 @@ on:
   push:
     paths-ignore:
       - '**/*.txt'
+      - '**/*.ini'
       - 'COPYING'
       - '.gitignore'
   pull_request:
     paths-ignore:
       - '**/*.txt'
+      - '**/*.ini'
       - 'COPYING'
       - '.gitignore'
     types:
@@ -102,7 +104,7 @@ jobs:
       - name: Start Docker container
         run: |
           docker pull $CONTAINER
-          docker run --name build-container -d -v ${{ github.workspace }}:/workspace $CONTAINER tail -f /dev/null
+          docker run --name build-container -d -v ${GITHUB_WORKSPACE}:/workspace $CONTAINER tail -f /dev/null
 
       - name: Update GPG keys for CUDA repo on Ubuntu 16.04
         if: matrix.sys.ct_os == 'ubuntu16.04'
@@ -147,8 +149,8 @@ jobs:
         env:
           SCRIPT: |
             cd /workspace
-            zip -9 -j ${{ steps.prepare.outputs.BASE_NAME }}.zip *
-            echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
+            zip -9 -j ${{ steps.prepare.outputs.BASE_NAME }}.zip Changelog.txt COPYING mfaktc mfaktc.ini README.txt
+            echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
             ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
             ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
         run: docker exec build-container bash -c "$SCRIPT"
@@ -162,7 +164,10 @@ jobs:
 
 # Begin job "build-win"
   build-win:
-    runs-on: ${{ matrix.sys.os }}
+    # windows-2022 also works and produces nearly identical binaries, so let's
+    # target the image that will be supported in the longer term. windows-2025
+    # is in beta as of June 2025, but testing has shown it is reliable.
+    runs-on: windows-2025
 
     strategy:
       # If set to true, all jobs within the same matrix (such as Linux or
@@ -170,30 +175,35 @@ jobs:
       fail-fast: false
 
       matrix:
-        # Available versions can be viewed at the Jimver/cuda-toolkit action sources:
-        # https://github.com/Jimver/cuda-toolkit/blob/v0.2.21/src/links/windows-links.ts
+        # Available CUDA versions can be viewed at the Jimver/cuda-toolkit action sources:
+        # https://github.com/Jimver/cuda-toolkit/blob/v0.2.24/src/links/windows-links.ts
         sys:
-          - { cuda_version: '12.9.0', os: 'windows-2022' }
-          - { cuda_version: '12.8.1', os: 'windows-2022' }
-          - { cuda_version: '12.6.3', os: 'windows-2022' }
-          - { cuda_version: '12.5.1', os: 'windows-2022' }
-          - { cuda_version: '12.4.1', os: 'windows-2022' }
-          - { cuda_version: '12.3.2', os: 'windows-2022' }
-          - { cuda_version: '12.2.2', os: 'windows-2022' }
-          - { cuda_version: '12.1.1', os: 'windows-2022' }
-          - { cuda_version: '12.0.1', os: 'windows-2022' }
-          - { cuda_version: '11.8.0', os: 'windows-2022' }
-          - { cuda_version: '11.7.1', os: 'windows-2022' }
-          - { cuda_version: '11.6.2', os: 'windows-2022' }
-          - { cuda_version: '11.5.2', os: 'windows-2022' }
-          - { cuda_version: '11.4.4', os: 'windows-2022' }
-          - { cuda_version: '11.3.1', os: 'windows-2022' }
-          - { cuda_version: '11.2.2', os: 'windows-2019' }
-          - { cuda_version: '11.1.1', os: 'windows-2019' }
-          - { cuda_version: '11.0.1', os: 'windows-2019' }
-          - { cuda_version: '10.0.130', os: 'windows-2019' }
-          - { cuda_version: '9.2.148', os: 'windows-2019' }
-          - { cuda_version: '8.0.61', os: 'windows-2019' }
+          - { cuda_version: '12.9.0' }
+          - { cuda_version: '12.8.1' }
+          - { cuda_version: '12.6.3' }
+          - { cuda_version: '12.5.1' }
+          - { cuda_version: '12.4.1' }
+          - { cuda_version: '12.3.2' }
+          - { cuda_version: '12.2.2' }
+          - { cuda_version: '12.1.1' }
+          - { cuda_version: '12.0.1' }
+          - { cuda_version: '11.8.0' }
+          - { cuda_version: '11.7.1' }
+          - { cuda_version: '11.6.2' }
+          - { cuda_version: '11.5.2' }
+          - { cuda_version: '11.4.4' }
+          - { cuda_version: '11.3.1' }
+          - { cuda_version: '11.2.2' }
+          - { cuda_version: '11.1.1' }
+          - { cuda_version: '11.0.1' }
+          - { cuda_version: '10.0.130' }
+          - { cuda_version: '9.2.148' }
+          - { cuda_version: '8.0.61' }
+
+    env:
+      MSVC_PKG_VC140: Microsoft.VisualStudio.Component.VC.140
+      MSVC_PKG_VC141: Microsoft.VisualStudio.Component.VC.v141.x86.x64
+      MSVC_SETUP_CMD: '"C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe" modify --passive --norestart --installPath "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"'
 
     steps:
 
@@ -224,41 +234,52 @@ jobs:
           bash .github/workflows/scripts/build_helper.sh ${{ matrix.sys.cuda_version }}
           cat .github/workflows/scripts/build_helper.sh.out >> $GITHUB_OUTPUT
 
-      - name: Build from sources with MSVC 2022 using PowerShell
-        if: ${{ matrix.sys.os == 'windows-2022' }}
-        shell: powershell
-        # MSVC 2022 on the Windows 2022 Server runner has a PowerShell script to
-        # launch a development shell.
-        run: |
-          & 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Launch-VsDevShell.ps1' -Arch amd64 -HostArch amd64
-          cd "${{ github.workspace }}\src"
-          Copy-Item mfaktc.ini ..
-          make SHELL="powershell.exe" -f Makefile.win
-
-      - name: Build from sources with MSVC 2019 using cmd.exe
-        if: ${{ matrix.sys.os == 'windows-2019' }}
+      - name: Build from sources with MSVC
         shell: cmd
-        # MSVC 2019 has a similar script on the Windows 2019 Server runner, but
-        # that only supports a 32-bit (x86) environment and doesn't allow
-        # setting the architecture.
-        # So we have to run a batch file to configure a 64-bit environment and
-        # then launch PowerShell from make afterwards. PowerShell is much better
-        # at handling long paths and quotes when invoked from make.
         run: |
-          "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" x64 ${{ env.VCVARS_VER }} & cd src & copy mfaktc.ini .. & make SHELL="powershell.exe" -f Makefile.win
+          ${{ env.MSVC_ADD_PKG_CMD }}
+          "${{ env.VCVARS_PATH }}" x64 ${{ env.VCVARS_VER }} & cd src & copy mfaktc.ini .. & make SHELL="powershell.exe" -j%NUMBER_OF_PROCESSORS% -f Makefile.win & cl /? 2>&1 | findstr /C:"Version" > clversion.log & echo Build finished
         env:
-          # -vcvars_ver=14.0 enables the MSVC 14.0 (2015) build environment -
-          # this is an MSVC 2019 component and not a complete MSVC instance.
-          VCVARS_VER: ${{ steps.prepare.outputs.CUDA_VER_MAJOR <= 10 && '-vcvars_ver=14.0' || '' }}
+          VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
+          # vcvars_ver=14.x enables Build Tools for previous MSVC versions:
+          # - 14.0 is for Visual Studio 2015
+          # - 14.16 is for Visual Studio 2017 version 15.9.x
+          # - 14.29 is for Visual Studio 2019 version 16.11.x
+          VCVARS_VER: >-
+            ${{ (
+                 steps.prepare.outputs.CUDA_VER_MAJOR <= 9 && '-vcvars_ver=14.0'
+              || steps.prepare.outputs.CUDA_VER_MAJOR == 10 && '-vcvars_ver=14.16'
+              || steps.prepare.outputs.CUDA_VER_MAJOR == 11 && steps.prepare.outputs.CUDA_VER_MINOR <= 2 && '-vcvars_ver=14.29'
+              || ''
+            ) }}
+          # Build Tools for Visual Studio 2019 (named VC142 internally) are
+          # included with windows-2022 and later. However, the Build Tools for
+          # older MSVC versions need to be installed by running '${MSVC_SETUP_CMD} --add <package name>'
+          #
+          # - ${MSVC_PKG_VC140} is required for 14.0 / MSVC 2015
+          # - ${MSVC_PKG_VC141} is required for 14.16 / MSVC 2017 version 15.9.x
+          MSVC_ADD_PKG_CMD: >-
+            ${{ (
+                 steps.prepare.outputs.CUDA_VER_MAJOR <= 9 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC140)
+              || steps.prepare.outputs.CUDA_VER_MAJOR == 10 && format('{0} --add {1}', env.MSVC_SETUP_CMD, env.MSVC_PKG_VC141)
+              || 'echo Build Tools already exist - installation not needed'
+            ) }}
 
       - name: Prepare build archive with description
         shell: bash
+        # We can't get the actual compiler (cl.exe) version with the helper
+        # script because cl might not be installed during the 'Prepare sources
+        # and gather info' step. COMPILER_VER is set to the MSVC rather than
+        # the cl version number, so we added a hack to log the cl version
+        # during the build step. Here, the cl version is extracted and added to
+        # the table along with the MSVC version.
         run: |
-          choco install -y --no-progress zip
-          zip -9 -j "${{ steps.prepare.outputs.BASE_NAME }}.zip" *
-          echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
+          [ -f src/clversion.log ] && CL_VER="$(grep -Eoe 'Version [\.0-9]+ ' src/clversion.log | cut -d' ' -f2)"
+          [ -z "$CL_VER" ] && CL_VER='Unknown'
+          tar -a -c -f "${{ steps.prepare.outputs.BASE_NAME }}.zip" Changelog.txt COPYING mfaktc-win-64.exe mfaktc.ini README.txt
+          echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
           ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
-          ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
+          ${CL_VER} (${{ steps.prepare.outputs.COMPILER_VER }}) | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -269,10 +290,8 @@ jobs:
 
 # Begin job "upload-release"
   upload-release:
-    # This job expects the Git tag name to begin with the version specified by
-    # MFAKTC_VERSION in params.h
-    # Otherwise, the job will fail because there is a version conflict between Git
-    # and params.h that must be resolved.
+    # Git tag name must begin with the version specified by MFAKTC_VERSION in
+    # params.h or else the job will fail
     if: github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/')
     needs: [ build-linux, build-win ]
     runs-on: ubuntu-latest
@@ -291,26 +310,25 @@ jobs:
       - name: Prepare asset list and release notes
         id: makeinfo
         run: |
-          if ! compgen -G "${{ env.base_name }}.txt" > /dev/null 2>&1; then
-            echo "::error ::Could not find release notes with mask ${{ env.base_name }}.txt"
+          if ! compgen -G "${base_name}.txt" > /dev/null 2>&1; then
+            echo "::error ::Could not find release notes with mask ${base_name}.txt"
             echo "::error ::Ensure the Git tag name begins with the version specified by MFAKTC_VERSION in src/params.h"
             exit 1
           fi
           {
-            echo "Binary releases (automated builds) as follows."
-            echo "Compute Capability (CC) in the table means minimum and maximum versions supported."
-            echo "CC versions are listed without the separator. For example, '90' means devices with compute capability 9.0 can run that build."
+            echo "Pre-compiled binaries (automated builds) as follows."
+            echo "In this table, the Compute Capability column means the minimum and maximum versions supported."
             echo
-            echo "File | CUDA version | Compute Capability | Build OS | Compiler version | NVCC version"
+            echo "File | CUDA version | Compute Capability | Build OS | Host compiler | NVCC version"
             echo "--- | --- | --- | --- | --- | ---"
-            sort -Vr ${{ env.base_name }}.txt
+            sort -Vr ${base_name}.txt
           } > RELEASE_NOTES.txt
           {
             echo 'RELEASE_FILES<<EOF'
-            printf '%s\n' ${{ env.base_name }}.zip | sort -Vr
+            printf '%s\n' "${base_name}.zip" | sort -Vr
             echo 'EOF'
           } > $GITHUB_OUTPUT
-          ( echo "${{ github.ref_name }}" | grep -qsP "v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(-(?:alpha|beta|pre))" && echo "PRERELEASE=true" || echo "PRERELEASE=false" ) >> $GITHUB_OUTPUT
+          ( echo "$GITHUB_REF_NAME" | grep -qsP "v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(-(?:alpha|beta|pre))" && echo "PRERELEASE=true" || echo "PRERELEASE=false" ) >> $GITHUB_OUTPUT
 
       - name: Create and upload release package
         uses: softprops/action-gh-release@v2.2.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: "CodeQL (advanced setup)"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '16 12 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: 'ubuntu-latest'
+    container: 'nvcr.io/nvidia/cuda:12.9.0-devel-ubuntu24.04'
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: c-cpp
+          build-mode: autobuild
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Perform CodeQL analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/scripts/build_helper.sh
+++ b/.github/workflows/scripts/build_helper.sh
@@ -69,8 +69,10 @@ elif [ ${#CC_LIST[*]} -lt 3 ]; then
   echo "Warning: less than three (3) supported compute capabilities" >&2
 fi
 
-echo "All supported CCs: ${CC_LIST[*]}, CC_MIN=${CC_LIST[0]}, CC_MAX=${CC_LIST[-1]}"
-echo -e "CC_LIST=\"${CC_LIST[*]}\"\nCC_MIN=${CC_LIST[0]}\nCC_MAX=${CC_LIST[-1]}" >> "$0.out"
+CC_MIN="${CC_LIST[0]:0:(-1)}.${CC_LIST[0]:(-1)}"
+CC_MAX="${CC_LIST[-1]:0:(-1)}.${CC_LIST[-1]:(-1)}"
+echo "All supported CCs: ${CC_LIST[*]}, CC_MIN=${CC_MIN}, CC_MAX=${CC_MAX}"
+echo -e "CC_LIST=\"${CC_LIST[*]}\"\nCC_MIN=${CC_MIN}\nCC_MAX=${CC_MAX}" >> "$0.out"
 
 echo 'Removing NVCCFLAGS strings with "arch=..." entries from makefiles and populating them with discovered supported values.'
 sed -i '/^NVCCFLAGS += --generate-code arch=compute.*/d' src/Makefile.win src/Makefile
@@ -87,13 +89,15 @@ if [ "$CUDA_VER" -lt 1200 ]; then
   sed -i -E 's/^(LDFLAGS = .*? -lcudart_static) (.*)/\1 -ldl -lrt -lpthread \2/' src/Makefile
 fi
 
-echo 'Gathering version info on generic compiler and NVCC...'
+echo 'Gathering host compiler and NVCC version info...'
+# COMPILER_VER for Windows builds is actually set to the MSVC product version.
+# We retrieve the cl.exe version during the build step and add it to the table.
 if [[ -x "$(command -v vswhere.exe)" ]]; then
-  CC_VSPROD="$(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property displayName)"
+  CC_VSPROD="$(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property displayName | sed -e 's/Visual Studio/MSVC/')"
   COMPILER_VER="${CC_VSPROD}, $(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion)"
 elif [[ -x "$(command -v powershell.exe)" ]]; then
   CC_VSINFO="$(powershell -Command Get-VSSetupInstance)"
-  CC_VSPROD="$(echo "$CC_VSINFO" | grep DisplayName | cut -d':' -f2 | xargs)"
+  CC_VSPROD="$(echo "$CC_VSINFO" | grep DisplayName | cut -d':' -f2 | xargs | sed -e 's/Visual Studio/MSVC/')"
   COMPILER_VER="${CC_VSPROD}, $(echo "$CC_VSINFO" | grep InstallationVersion | cut -d':' -f2 | xargs)"
 else
   COMPILER_VER="$(gcc --version | head -n1)"
@@ -104,11 +108,11 @@ else
 fi
 
 if [[ -x "$(command -v powershell.exe)" ]]; then
-  OS_VER="$(powershell -Command "[System.Environment]::OSVersion.VersionString")"
+  OS_VER="$(powershell -Command "[System.Environment]::OSVersion.VersionString" | cut -d ' ' -f2-)"
   OS_TYPE="win64"
 fi
 
-NVCC_VER="$(nvcc --version | tail -n1 | sed -E 's/^Build //')"
+NVCC_VER="$(nvcc --version | tail -n1 | sed -E 's/^Build //;s/^Cuda compilation tools, //')"
 
 # get mfaktc version from src/params.h
 # match SemVer and GIMPS version strings: https://regex101.com/r/m38d3i/2

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,3 +1,24 @@
+version 0.23.5
+==============================
+- includes changes backported from mfaktc 0.24.0
+
+bug fixes:
+- Blackwell devices are now correctly supported on Windows (thanks to
+  yellowbeeblackbee)
+
+build:
+- enabled more compiler optimizations by default for a slight performance gain
+  (thanks to NStorm)
+- various improvements to GitHub Actions workflows (thanks to NStorm)
+  - support for additional CUDA versions
+  - removed dependency on deprecated windows-2019 images
+  - code analysis with CodeQL
+- improved visual appearance and clarity of release information (thanks to
+  Danny Chia)
+
+other changes:
+- re-organized mfaktc.ini to be more user-friendly (thanks to James Heinrich)
+
 version 0.23.4
 ==============================
 - includes changes backported from mfaktc 0.24.0

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,12 +5,12 @@ CUDA_LIB = -L$(CUDA_DIR)/lib64/
 
 # compiler settings for .c files (CPU)
 CC = gcc
-CFLAGS = -Wall -Wextra -O2 $(CUDA_INCLUDE) -malign-double
+CFLAGS = -Wall -Wextra -O3 -flto -malign-double -ffunction-sections -fdata-sections -Wl,--gc-sections $(CUDA_INCLUDE)
 CFLAGS_EXTRA_SIEVE = -funroll-all-loops
 
 # compiler settings for .cu files (GPU)
 NVCC = nvcc
-NVCCFLAGS = $(CUDA_INCLUDE) --ptxas-options=-v -Wno-deprecated-gpu-targets
+NVCCFLAGS = $(CUDA_INCLUDE) --ptxas-options=-v -O3 -Wno-deprecated-gpu-targets
 
 # generate code for supported compute capabilities
 # NVCCFLAGS += --generate-code arch=compute_11,code=sm_11 # mfaktc cannot use 1.0 but supports 1.1 and above
@@ -36,7 +36,7 @@ NVCCFLAGS += --compiler-options=-Wall
 
 # Linker
 LD = gcc
-LDFLAGS = -fPIC $(CUDA_LIB) -lcudart_static -lm -lstdc++
+LDFLAGS = -flto -fPIC -Wl,--gc-sections $(CUDA_LIB) -lcudart_static -lm -lstdc++
 
 INSTALL = install
 

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -1,8 +1,8 @@
 CC = cl
-CFLAGS = /Ox /Oy /W2 /fp:fast /I"$(CUDA_PATH)\include" /I"$(CUDA_PATH)\include\cudart" /nologo
+CFLAGS = /O2 /Oy /W2 /fp:fast /I"$(CUDA_PATH)\include" /I"$(CUDA_PATH)\include\cudart" /nologo
 
-NVCCFLAGS = -m64 --ptxas-options=-v -Wno-deprecated-gpu-targets
-CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /Ox" $(NVCCFLAGS)
+NVCCFLAGS = -m64 -O3 --ptxas-options=-v -Wno-deprecated-gpu-targets
+CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /O2" $(NVCCFLAGS)
 
 ############################################################
 
@@ -51,10 +51,10 @@ clean :
 	$(CC) $(CFLAGS) /c /Tp $<
 
 tf_75bit.obj : tf_96bit.cu
-	nvcc -O2 -c $< -o $@ $(CUFLAGS) -DSHORTCUT_75BIT
+	nvcc -c $< -o $@ $(CUFLAGS) -DSHORTCUT_75BIT
 
 %.obj : %.cu
-	nvcc -O2 -c $< -o $@ $(CUFLAGS)
+	nvcc -c $< -o $@ $(CUFLAGS)
 
 ..\\%.ini : %.ini
 	$(INSTALL) $< ..

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -18,6 +18,7 @@ NVCCFLAGS += --generate-code arch=compute_86,code=sm_86
 NVCCFLAGS += --generate-code arch=compute_87,code=sm_87
 NVCCFLAGS += --generate-code arch=compute_89,code=sm_89
 NVCCFLAGS += --generate-code arch=compute_90,code=sm_90
+NVCCFLAGS += --generate-code arch=compute_120,code=sm_120
 
 ############################################################
 

--- a/src/mfaktc.ini
+++ b/src/mfaktc.ini
@@ -1,34 +1,32 @@
-# SievePrimes defines how far the factor candidates (FCs) are pre-sieved on
-# the CPU. The first <SievePrimes> odd primes are used to sieve the FCs.
+##
+## User settings that are commonly modified:
+##
+
+# Prepend a user ID and computer name to each result in the results file,
+# similar to Prime95 and mprime. Both V5UserID and ComputerID must be set to
+# enable this feature.
 #
-# Minimum: SievePrimes=2000 (check SievePrimesMin)
-# Maximum: SievePrimes=200000
+# Default: none (unset)
 #
-# Default: SievePrimes=25000
+#V5UserID=<PrimeNet ID>
+#ComputerID=<hostname>
 
-SievePrimes=25000
-
-
-# Set this to 1 to enable automatic adjustments of SievePrimes during
-# runtime based on the "average wait times".
+# GPUSieveSize defines the size of the GPU sieve to use, in Mib.
+# Default is set to 256 for maximum compatibility and to avoid issues on older
+# devices. Using a value of 2047 can give better performance on newer GPUs.
 #
-# Default: SievePrimesAdjust=1
-
-SievePrimesAdjust=1
-
-
-# Set the minimum and maximum limit for SievePrimes; this is needed if
-# SievePrimesAdjust is enabled. These are soft limits; there are hard limits
-# in the code which should never ever be changed.
+# Minimum: GPUSieveSize=4
+# Maximum: GPUSieveSize=2047
 #
-# Current limits are:
-# 2000 <= SievePrimesMin <= SievePrimes <= SievePrimesMax <= 200000
-#
-# Default: SievePrimesMin=5000
-#          SievePrimesMax=100000
+# Default: GPUSieveSize=256
 
-SievePrimesMin=5000
-SievePrimesMax=100000
+#GPUSieveSize=2047
+GPUSieveSize=256
+
+
+##
+## Other optional configuration settings:
+##
 
 
 # Set the number of CUDA streams / data sets.
@@ -129,7 +127,9 @@ Stages=0
 # 0: Do not stop the current assignment after a factor is found.
 # 1: Stop at the current bit level after finding a factor. Only makes sense
 #    when Stages is enabled.
-# 2: Stop at the current class after finding a factor
+# 2: Stop at the current class after finding a factor. Leaves bit level
+#    incomplete and may result in reduced GIMPS credit depending on factor
+#    size. Strongly discouraged.
 #
 # Default: StopAfterFactor=1
 
@@ -152,25 +152,6 @@ PrintMode=1
 # Default: Logging=0
 
 Logging=0
-
-
-# allow the CPU to sleep when idle?
-# 0: Do not sleep if the CPU must wait for the GPU
-# 1: The CPU can sleep for a short time
-#
-# Default: AllowSleep=0
-
-AllowSleep=0
-
-
-# Prepend a user ID and computer name to each result in the results file,
-# similar to Prime95 and mprime. Both V5UserID and ComputerID must be set to
-# enable this feature.
-#
-# Default: none (unset)
-#
-#V5UserID=<PrimeNet ID>
-#ComputerID=<hostname>
 
 
 # TimeStampInResults determines whether each line in the results file is
@@ -211,7 +192,7 @@ TimeStampInResults=0
 # candidates when sieving on the GPU, but only the post-processed factor
 # candidates when sieving on the CPU.
 
-# mfaktc 0.20+ (default)
+# mfaktc 0.20 (default)
 ProgressHeader=Date    Time | class   Pct |   time     ETA | GHz-d/day    Sieve     Wait
 ProgressFormat=%d %T | %C %p%% | %t  %e |  %g  %s  %W%%
 
@@ -245,16 +226,8 @@ SieveOnGPU=1
 # Default: GPUSievePrimes=82486
 
 GPUSievePrimes=82486
-
-
-# GPUSieveSize defines the size of the GPU sieve to use, in Mib.
-#
-# Minimum: GPUSieveSize=4
-# Maximum: GPUSieveSize=2047
-#
-# Default: GPUSieveSize=256
-
-GPUSieveSize=256
+#GPUSievePrimes=15000
+#GPUSievePrimes=8000
 
 
 # GPUSieveProcessSize defines the size of the sieve each TF block
@@ -270,3 +243,51 @@ GPUSieveSize=256
 # Default: GPUSieveProcessSize=16
 
 GPUSieveProcessSize=16
+
+
+##
+## CPU sieving settings (obsolete and may be removed in the future)
+##
+
+
+# Sets whether to allow the CPU to sleep for a short time when idle; this
+# usually happens when the CPU has to wait for the GPU.
+# 0: Disable CPU sleep
+# 1: Enable CPU sleep
+#
+# Default: AllowSleep=0
+
+AllowSleep=1
+
+
+# SievePrimes defines how far the factor candidates (FCs) are pre-sieved on
+# the CPU. The first <SievePrimes> odd primes are used to sieve the FCs.
+#
+# Minimum: SievePrimes=2000 (check SievePrimesMin)
+# Maximum: SievePrimes=200000
+#
+# Default: SievePrimes=25000
+
+SievePrimes=25000
+
+
+# Set this to 1 to enable automatic adjustments of SievePrimes during
+# runtime based on the "average CPU wait"
+#
+# Default: SievePrimesAdjust=1
+
+SievePrimesAdjust=1
+
+
+# Set the minimum and maximum limit for SievePrimes; this is needed if
+# SievePrimesAdjust is enabled. Configured values are soft limits; there are
+# hard limits in the code which should never ever be changed.
+#
+# Current limits are:
+# 2000 <= SievePrimesMin <= SievePrimes <= SievePrimesMax <= 200000
+#
+# Default: SievePrimesMin=5000
+#          SievePrimesMax=100000
+
+SievePrimesMin=5000
+SievePrimesMax=100000

--- a/src/params.h
+++ b/src/params.h
@@ -89,7 +89,7 @@ code path */
  Please discuss with the community before making changes to version numbers!
  */
 
-#define MFAKTC_VERSION "0.23.4"
+#define MFAKTC_VERSION "0.23.5"
 
 
 /*


### PR DESCRIPTION
Backported applicable changes from mfaktc 0.24.0 to the `0.23` branch. Integrates changes from the following PRs:

* #34
* #42
* #44
* #45
* #47
* #49