### PR TITLE
Remove deprecated Compute 5.0 from Makefile.win

### DIFF
--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -6,7 +6,6 @@ CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /O2" $(NVCCFLAGS)
 
 ############################################################
 
-NVCCFLAGS += --generate-code arch=compute_50,code=sm_50
 NVCCFLAGS += --generate-code arch=compute_60,code=sm_60
 NVCCFLAGS += --generate-code arch=compute_61,code=sm_61
 NVCCFLAGS += --generate-code arch=compute_62,code=sm_62


### PR DESCRIPTION
CUDA 13.0 (I think 12.9 maybe earlier actually removed this) doesn't support CC 5.0. This PR removes the build flag from Makefile.win to make compiling slightly more convenient for Windows users since they don't have to edit the line out themselves.