### PR TITLE
Bump stable version to 0.23.6 and update makefiles

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -11,6 +11,8 @@ bug fixes:
 
 build:
 - added CUDA 13.x support (thanks to NStorm)
+  - this drops support for compute capability 7.2 and below - developers using
+    older CUDA versions should uncomment the relevant lines in the makefile
 
 other changes:
 - code has been revamped to improve formatting and maintain consistent style

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,4 +1,4 @@
-version 0.23.5
+version 0.23.6
 ==============================
 - includes changes backported from mfaktc 0.24.0
 
@@ -7,9 +7,24 @@ enhancements:
   - users should see a small performance improvement on newer devices
 
 bug fixes:
+- fixed some typos in code comments and program output
+
+build:
+- added CUDA 13.x support (thanks to NStorm)
+
+other changes:
+- code has been revamped to improve formatting and maintain consistent style
+  (thanks to NStorm)
+- updated print_dez96() to use int96 data type (thanks to NStorm)
+  - converted some hard-coded values to macros
+
+version 0.23.5
+==============================
+- includes changes backported from mfaktc 0.24.0
+
+bug fixes:
 - added build flags to enable support for Blackwell devices by default in
   Makefile.win (thanks to yellowbeeblackbee)
-- fixed some typos in code comments and program output
 
 build:
 - enabled more compiler optimizations by default for a slight performance gain
@@ -23,11 +38,7 @@ build:
 - added CUDA 13.x support (thanks to NStorm)
 
 other changes:
-- code has been revamped to improve formatting and maintain consistent style
-  (thanks to NStorm)
 - re-organized mfaktc.ini to be more user-friendly (thanks to James Heinrich)
-- updated print_dez96() to use int96 data type (thanks to NStorm)
-  - converted some hard-coded values to macros
 
 version 0.23.4
 ==============================

--- a/README.txt
+++ b/README.txt
@@ -86,6 +86,11 @@ In any case, a 64-bit build is preferred except on some old low-end GPUs.
 Testing on an Intel Core i7 CPU has shown that the performance-critical CPU
 code runs about 33% faster compared to 32 bits.
 
+It should be noted that each CUDA version only supports specific compute
+capabilities. You may have to comment out the appropriate lines in the makefile
+before compiling mfaktc. Use this table to determine which compute capabilities
+are supported: https://en.wikipedia.org/wiki/CUDA#GPUs_supported
+
 #############
 # 2.1 Linux #
 #############

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,19 +15,21 @@ NVCCFLAGS = $(CUDA_INCLUDE) --ptxas-options=-v -O3 -Wno-deprecated-gpu-targets
 # generate code for compute capabilities - see this table for supported
 # versions: https://en.wikipedia.org/wiki/CUDA#GPUs_supported
 
-# deprecated - uncomment to use
+# deprecated since CUDA 12.x - uncomment to use
 # NVCCFLAGS += --generate-code arch=compute_11,code=sm_11 # mfaktc cannot use 1.0 but supports 1.1 and above
 # NVCCFLAGS += --generate-code arch=compute_20,code=sm_20 # Fermi GPUs
 # NVCCFLAGS += --generate-code arch=compute_30,code=sm_30 # early Kepler GPUs
 # NVCCFLAGS += --generate-code arch=compute_35,code=sm_35 # later Kepler GPUs; funnel shift added in 3.2
 
+# deprecated since CUDA 13.x - uncomment to use
+# NVCCFLAGS += --generate-code arch=compute_50,code=sm_50 # Maxwell GPUs
+# NVCCFLAGS += --generate-code arch=compute_60,code=sm_60
+# NVCCFLAGS += --generate-code arch=compute_61,code=sm_61
+# NVCCFLAGS += --generate-code arch=compute_62,code=sm_62
+# NVCCFLAGS += --generate-code arch=compute_70,code=sm_70
+# NVCCFLAGS += --generate-code arch=compute_72,code=sm_72
+
 # currently supported
-NVCCFLAGS += --generate-code arch=compute_50,code=sm_50 # Maxwell GPUs
-NVCCFLAGS += --generate-code arch=compute_60,code=sm_60
-NVCCFLAGS += --generate-code arch=compute_61,code=sm_61
-NVCCFLAGS += --generate-code arch=compute_62,code=sm_62
-NVCCFLAGS += --generate-code arch=compute_70,code=sm_70
-NVCCFLAGS += --generate-code arch=compute_72,code=sm_72
 NVCCFLAGS += --generate-code arch=compute_75,code=sm_75
 NVCCFLAGS += --generate-code arch=compute_80,code=sm_80
 NVCCFLAGS += --generate-code arch=compute_86,code=sm_86

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,11 +12,16 @@ CFLAGS_EXTRA_SIEVE = -funroll-all-loops
 NVCC = nvcc
 NVCCFLAGS = $(CUDA_INCLUDE) --ptxas-options=-v -O3 -Wno-deprecated-gpu-targets
 
-# generate code for supported compute capabilities
+# generate code for compute capabilities - see this table for supported
+# versions: https://en.wikipedia.org/wiki/CUDA#GPUs_supported
+
+# deprecated - uncomment to use
 # NVCCFLAGS += --generate-code arch=compute_11,code=sm_11 # mfaktc cannot use 1.0 but supports 1.1 and above
 # NVCCFLAGS += --generate-code arch=compute_20,code=sm_20 # Fermi GPUs
 # NVCCFLAGS += --generate-code arch=compute_30,code=sm_30 # early Kepler GPUs
 # NVCCFLAGS += --generate-code arch=compute_35,code=sm_35 # later Kepler GPUs; funnel shift added in 3.2
+
+# currently supported
 NVCCFLAGS += --generate-code arch=compute_50,code=sm_50 # Maxwell GPUs
 NVCCFLAGS += --generate-code arch=compute_60,code=sm_60
 NVCCFLAGS += --generate-code arch=compute_61,code=sm_61

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -9,15 +9,15 @@ CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /O2" $(NVCCFLAGS)
 # generate code for compute capabilities - see this table for supported
 # versions: https://en.wikipedia.org/wiki/CUDA#GPUs_supported
 
-# deprecated - uncomment to use
+# deprecated in CUDA 13.x and above - uncomment to use
 # NVCCFLAGS += --generate-code arch=compute_50,code=sm_50
+# NVCCFLAGS += --generate-code arch=compute_60,code=sm_60
+# NVCCFLAGS += --generate-code arch=compute_61,code=sm_61
+# NVCCFLAGS += --generate-code arch=compute_62,code=sm_62
+# NVCCFLAGS += --generate-code arch=compute_70,code=sm_70
+# NVCCFLAGS += --generate-code arch=compute_72,code=sm_72
 
 # currently supported
-NVCCFLAGS += --generate-code arch=compute_60,code=sm_60
-NVCCFLAGS += --generate-code arch=compute_61,code=sm_61
-NVCCFLAGS += --generate-code arch=compute_62,code=sm_62
-NVCCFLAGS += --generate-code arch=compute_70,code=sm_70
-NVCCFLAGS += --generate-code arch=compute_72,code=sm_72
 NVCCFLAGS += --generate-code arch=compute_75,code=sm_75
 NVCCFLAGS += --generate-code arch=compute_80,code=sm_80
 NVCCFLAGS += --generate-code arch=compute_86,code=sm_86

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -6,7 +6,13 @@ CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /O2" $(NVCCFLAGS)
 
 ############################################################
 
-NVCCFLAGS += --generate-code arch=compute_50,code=sm_50
+# generate code for compute capabilities - see this table for supported
+# versions: https://en.wikipedia.org/wiki/CUDA#GPUs_supported
+
+# deprecated - uncomment to use
+# NVCCFLAGS += --generate-code arch=compute_50,code=sm_50
+
+# currently supported
 NVCCFLAGS += --generate-code arch=compute_60,code=sm_60
 NVCCFLAGS += --generate-code arch=compute_61,code=sm_61
 NVCCFLAGS += --generate-code arch=compute_62,code=sm_62

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -9,7 +9,7 @@ CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /O2" $(NVCCFLAGS)
 # generate code for compute capabilities - see this table for supported
 # versions: https://en.wikipedia.org/wiki/CUDA#GPUs_supported
 
-# deprecated in CUDA 13.x and above - uncomment to use
+# deprecated since CUDA 13.x - uncomment to use
 # NVCCFLAGS += --generate-code arch=compute_50,code=sm_50
 # NVCCFLAGS += --generate-code arch=compute_60,code=sm_60
 # NVCCFLAGS += --generate-code arch=compute_61,code=sm_61

--- a/src/Makefile.win32
+++ b/src/Makefile.win32
@@ -6,7 +6,9 @@ CC_PATH = $(shell where cl)
 NVCCFLAGS = -m32 --ptxas-options=-v -Wno-deprecated-gpu-targets
 CUFLAGS = -ccbin="$(CC_PATH)" -Xcompiler "/EHsc /W3 /nologo /Ox /GL" $(NVCCFLAGS)
 
-# generate code for supported compute capabilities
+# generate code for compute capabilities - some may be unsupported in newer
+# CUDA versions. See this table for details:
+# https://en.wikipedia.org/wiki/CUDA#GPUs_supported
 NVCCFLAGS += --generate-code arch=compute_11,code=sm_11 # mfaktc cannot use 1.0 but supports 1.1 and above
 NVCCFLAGS += --generate-code arch=compute_20,code=sm_20 # Fermi GPUs
 NVCCFLAGS += --generate-code arch=compute_30,code=sm_30 # early Kepler GPUs

--- a/src/params.h
+++ b/src/params.h
@@ -82,7 +82,7 @@ code path */
  Please discuss with the community before making changes to version numbers!
  */
 
-#define MFAKTC_VERSION "0.23.5"
+#define MFAKTC_VERSION "0.23.6"
 
 /*
 THREADS_PER_BLOCK has a hardware limit, 512 on GPUs with compute capability


### PR DESCRIPTION
Updated the version number to 0.23.6 and moved changes since July 2025 to the new 0.23.6 section in the changelog accordingly. Also commented out compute capabilities up to 7.2 in the Windows makefile because CUDA 13.x only supports 7.5 and above: https://en.wikipedia.org/wiki/CUDA#GPUs_supported