### PR TITLE
CI/CD: support recent CUDA versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,7 +180,8 @@ jobs:
         # Available CUDA versions can be viewed at the Jimver/cuda-toolkit action sources:
         # https://github.com/Jimver/cuda-toolkit/blob/v0.2.24/src/links/windows-links.ts
         sys:
-          - { cuda_version: '12.9.0' }
+          - { cuda_version: '13.0.0' }
+          - { cuda_version: '12.9.1' }
           - { cuda_version: '12.8.1' }
           - { cuda_version: '12.6.3' }
           - { cuda_version: '12.5.1' }
@@ -217,10 +218,10 @@ jobs:
 
       - name: Install CUDA Toolkit
         id: cuda-toolkit
-        uses: Jimver/cuda-toolkit@v0.2.24
+        uses: N-Storm/cuda-toolkit@v0.2.27m
         with:
           cuda: ${{ matrix.sys.cuda_version }}
-          sub-packages: ${{ startsWith(matrix.sys.cuda_version, '8.') && '[]' || '[ "nvcc", "cudart" ]' }}
+          sub-packages: ${{ startsWith(matrix.sys.cuda_version, '8.') && '[]' || startsWith(matrix.sys.cuda_version, '13.') &&'[ "nvcc", "crt", "cudart", "nvvm", "nvptxcompiler" ]' || '[ "nvcc", "cudart" ]' }}
           use-local-cache: false
           use-github-cache: false
 


### PR DESCRIPTION
This adds support for CUDA 13.0.0 and 12.9.1 builds on Windows.  
I had to fork the original GitHub action used for installing CUDA on Windows.  
Since its dependencies were updated, recent versions no longer work on Windows and a fix may take some time.  

In the fork, I reverted to the last working version with older libs and backported the commits that add newer CUDA versions.  
Once the upstream action is fixed, we can switch back to it.

PS: I considered creating a patched fork of cuda-toolkit under the `primesearch` org, but I hope this is only temporary and will not be needed once the upstream issue is resolved.