### PR TITLE
clean up `--help` output

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -84,8 +84,11 @@ code runs about 33% faster compared to 32 bits.
 
 It should be noted that each CUDA version only supports specific compute
 capabilities. You may have to enable or disable certain flags in the makefile
-before compiling mfaktc. Use this table to determine which compute capabilities
-are supported: https://en.wikipedia.org/wiki/CUDA#GPUs_supported
+before compiling mfaktc, or nvcc may exit due to an "unsupported gpu
+architecture" error.
+
+Use this table to determine which compute capabilities are supported:
+https://en.wikipedia.org/wiki/CUDA#GPUs_supported
 
 #############
 # 2.1 Linux #
@@ -99,10 +102,7 @@ Steps:
 - optional: run "make clean" to remove any build artifacts
 - make
 
-nvcc may exit due to an "unsupported gpu architecture" error. If this happens,
-simply comment out the corresponding "NVCCFLAGS += ..." line in the makefile.
-You may have to do this more than once. Otherwise, the binary "mfaktc" should
-appear in the parent folder.
+If compilation succeeds, the binary "mfaktc" should appear in the root folder.
 
 mfaktc was originally compiled with:
 - OpenSUSE 12.2 x86_64

--- a/src/cuda_utils.cu
+++ b/src/cuda_utils.cu
@@ -11,7 +11,7 @@ mfaktc is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-                                
+
 You should have received a copy of the GNU General Public License
 along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -74,11 +74,11 @@ extern "C" __host__ int check_subcc_bug(mystuff_t *mystuff)
         else {
             printf("  ERROR: output != input\n");
             printf("\n");
-            printf("  could be caused by bad software environment (CUDA toolkit and/or graphics driver)\n");
-            printf("  Known bad:\n");
-            printf("    - CUDA 5.0.7RC + 302.06.03 with all supported GPUs\n");
-            printf("      fixed by driver update after reported this issue to nvidia\n");
-            printf("    - CUDA 7.0 + 346.47, 346.59, 346.72 and 349.16 346.72 with Maxwell GPUs\n");
+            printf("  could be due to a bad software environment (CUDA Toolkit or graphics driver, or both)\n");
+            printf("  Configurations known to be bad:\n");
+            printf("    - CUDA 5.0 + 302.06.03 on all supported GPUs\n");
+            printf("      fixed in driver update after issue reported to Nvidia\n");
+            printf("    - CUDA 7.0 + 346.47, 346.59, 346.72 and 349.16 on Maxwell GPUs\n");
         }
         printf("\n");
     }

--- a/src/output.c
+++ b/src/output.c
@@ -43,7 +43,7 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 
 void print_help(char *string)
 {
-    printf("mfaktc v%s\n", MFAKTC_VERSION);
+    printf("mfaktc %s\n", MFAKTC_VERSION);
     printf("Copyright (c) 2009-2015, 2018, 2019, 2024 Oliver Weihe (o.weihe@t-online.de)\n\n", MFAKTC_VERSION);
     printf("This program comes with ABSOLUTELY NO WARRANTY; for details see COPYING.\n");
     printf("This is free software, and you are welcome to redistribute it\n");

--- a/src/output.c
+++ b/src/output.c
@@ -1,6 +1,6 @@
 /*
 This file is part of mfaktc.
-Copyright (C) 2009-2015, 2018, 2019, 2024  Oliver Weihe (o.weihe@t-online.de)
+Copyright (c) 2009-2015, 2018, 2019, 2024  Oliver Weihe (o.weihe@t-online.de)
                                            Bertram Franz (bertramf@gmx.net)
 
 mfaktc is free software: you can redistribute it and/or modify
@@ -43,23 +43,25 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 
 void print_help(char *string)
 {
-    printf("mfaktc v%s Copyright (C) 2009-2015, 2018, 2019, 2024 Oliver Weihe (o.weihe@t-online.de)\n", MFAKTC_VERSION);
+    printf("mfaktc v%s\n", MFAKTC_VERSION);
+    printf("Copyright (c) 2009-2015, 2018, 2019, 2024 Oliver Weihe (o.weihe@t-online.de)\n\n", MFAKTC_VERSION);
     printf("This program comes with ABSOLUTELY NO WARRANTY; for details see COPYING.\n");
     printf("This is free software, and you are welcome to redistribute it\n");
     printf("under certain conditions; see COPYING for details.\n\n\n");
 
     printf("Usage: %s [options]\n", string);
-    printf("  -h                     display this help and exit\n");
-    printf("  -d <device number>     specify the device number used by this program\n");
-    printf("  -tf <exp> <min> <max>  trial factor %s<exp> from 2^<min> to 2^<max> and exit\n", NAME_NUMBERS);
-    printf("                         instead of parsing the worktodo file\n");
+    printf("  -h                     display this help\n");
+    printf("  -d <device number>     specify device to use\n");
+    printf("  -tf <exp> <min> <max>  trial factor %s<exp> from <min> to <max> bits,\n", NAME_NUMBERS);
+    printf("                         ignores worktodo file\n");
     printf("  -st                    run built-in self-test and exit\n");
-    printf("  -st2                   same as -st but extended range for k_min and k_max\n");
-    printf("  -v <number>            set verbosity (min = 0, default = 1, more = 2, max = 3)\n");
+    printf("  -st2                   same as -st but use extended range for k_min and k_max\n");
+    printf("  -v <number>            verbosity level: terse = 0, default = 1, more = 2,\n");
+    printf("                                          maximum = 3\n");
     printf("\n");
     printf("options for debugging purposes\n");
-    printf("  --timertest            run test of timer functions and exit\n");
-    printf("  --sleeptest            run test of sleep functions and exit\n");
+    printf("  --timertest            test timer functions\n");
+    printf("  --sleeptest            test sleep functions\n");
 }
 
 void logprintf(mystuff_t *mystuff, const char *fmt, ...)

--- a/src/params.h
+++ b/src/params.h
@@ -198,6 +198,6 @@ The following lines define the min, default and max value.
 #define MAX_BUFFER_LENGTH              (MAX_FACTOR_BUFFER_LENGTH + 100)
 #define MAX_CHECKPOINT_FILENAME_LENGTH 40
 
-#define GHZDAYS_MAGIC_TF_TOP           0.016968 // magic constant for TF to 65-bit and above
-#define GHZDAYS_MAGIC_TF_MID           0.017832 // magic constant for 63-and 64-bit
-#define GHZDAYS_MAGIC_TF_BOT           0.011160 // magic constant for 62-bit and below
+#define GHZDAYS_MAGIC_TF_TOP           0.016968 // magic constant for TF to 65 bits and above
+#define GHZDAYS_MAGIC_TF_MID           0.017832 // magic constant for 63 and 64 bits
+#define GHZDAYS_MAGIC_TF_BOT           0.011160 // magic constant for 62 bits and below


### PR DESCRIPTION
Updated the output of `--help` to better align with mfakto:
* improved the wording
* added line breaks to improve readability
* dropped the "v" from the title as it is not compatible with SemVer. While "v" can be used to indicate a version number, it is not used in mfakto and has been removed to maintain consistency

A few other changes:
* updated the error message in `cuda_utils.cu`
* slightly re-organized the readme