### PR TITLE
Remove unnecessary printf() argument

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -44,7 +44,7 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 void print_help(char *string)
 {
     printf("mfaktc %s\n", MFAKTC_VERSION);
-    printf("Copyright (c) 2009-2015, 2018, 2019, 2024 Oliver Weihe (o.weihe@t-online.de)\n\n", MFAKTC_VERSION);
+    printf("Copyright (c) 2009-2015, 2018, 2019, 2024 Oliver Weihe (o.weihe@t-online.de)\n\n");
     printf("This program comes with ABSOLUTELY NO WARRANTY; for details see COPYING.\n");
     printf("This is free software, and you are welcome to redistribute it\n");
     printf("under certain conditions; see COPYING for details.\n\n\n");


### PR DESCRIPTION
An extra argument was left in one of the `printf()` calls after the version string was moved to a separate line in ac4a3a28.