### PR TITLE
Unique random temp file name

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -12,6 +12,7 @@ new features:
 enhancements:
 - merged in file locking code from mfakto to reduce concurrency (thanks to
   James Heinrich)
+- worktodo updates now use unique random temp files "__worktodo__.XXXXXX"
 - updated mul_96() to use 64-bit integers (thanks to NStorm)
   - users should see a small performance increase with CUDA 12.x and above
 

--- a/src/filelocking.c
+++ b/src/filelocking.c
@@ -19,6 +19,7 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
 #include <fcntl.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
@@ -57,6 +58,21 @@ typedef struct _lockinfo {
 
 static unsigned int num_locked_files = 0;
 static lockinfo locked_files[MAX_LOCKED_FILES];
+
+int make_temp_file(char *tpl)
+{
+#if defined _MSC_VER || defined __MINGW32__
+    return _mktemp_s(tpl, strlen(tpl) + 1);
+#else
+    int _temp_fd = mkstemp(tpl);
+    if (!_temp_fd)
+        return EINVAL;
+    else {
+        close(_temp_fd);
+        return 0;
+    }
+#endif
+}
 
 FILE *fopen_and_lock(const char *path, const char *mode)
 {

--- a/src/filelocking.c
+++ b/src/filelocking.c
@@ -67,10 +67,8 @@ int make_temp_file(char *tpl)
     int _temp_fd = mkstemp(tpl);
     if (!_temp_fd)
         return EINVAL;
-    else {
-        close(_temp_fd);
-        return 0;
-    }
+    close(_temp_fd);
+    return 0;
 #endif
 }
 

--- a/src/filelocking.h
+++ b/src/filelocking.h
@@ -21,6 +21,19 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 extern "C" {
 #endif
 
+/**
+ * @brief Creates a temporary file using the provided template string.
+ *
+ * On Windows (_MSC_VER or __MINGW32__), uses _mktemp_s to generate a unique filename.
+ * On other platforms, uses mkstemp to create and open a unique temporary file, then closes it.
+ *
+ * @param tpl A modifiable string containing the template for the temporary filename.
+ *            The string should contain a sequence of 'X's that will be replaced to
+ *            generate a unique filename.
+ * @return 0 on success, or an error code (e.g., EINVAL) on failure.
+ */
+int make_temp_file(char *tpl);
+
 FILE *fopen_and_lock(const char *path, const char *mode);
 int unlock_and_fclose(FILE *f);
 

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -1158,7 +1158,7 @@ int main(int argc, char **argv)
                                 logprintf(&mystuff, "ERROR: clear_assignment() / modify_assignment(): can't open \"%s\"\n",
                                           mystuff.workfile);
                             else if (parse_ret == CANT_OPEN_TEMPFILE)
-                                logprintf(&mystuff, "ERROR: clear_assignment() / modify_assignment(): can't open \"__worktodo__.tmp\"\n");
+                                logprintf(&mystuff, "ERROR: clear_assignment() / modify_assignment(): can't create temp file\n");
                             else if (parse_ret == ASSIGNMENT_NOT_FOUND)
                                 logprintf(&mystuff, "ERROR: clear_assignment() / modify_assignment(): assignment not found in \"%s\"\n",
                                           mystuff.workfile);

--- a/src/parse.c
+++ b/src/parse.c
@@ -450,7 +450,7 @@ enum ASSIGNMENT_ERRORS clear_assignment(char *filename, unsigned int exponent, i
   }	// while.....
   unlock_and_fclose(f_in);
   f_in = NULL;
-  unlock_and_fclose(f_out);
+  fclose(f_out);
   f_out = NULL;
   if (!found)
     return ASSIGNMENT_NOT_FOUND;

--- a/src/parse.c
+++ b/src/parse.c
@@ -44,7 +44,7 @@ mfaktc 0.07-0.14 to see Luigi's code.
  *     1 - get_next_assignment : cannot open file                                                           *
  *     2 - get_next_assignment : no valid assignment found                                                  *
  *     3 - clear_assignment    : cannot open file <filename>                                                *
- *     4 - clear_assignment    : cannot open file "__worktodo__.tmp"                                        *
+ *     4 - clear_assignment    : cannot open temp file from template "__worktodo__.XXXXXX"                  *
  *     5 - clear_assignment    : assignment not found                                                       *
  *     6 - clear_assignment    : cannot rename temporary workfile to regular workfile                       *
  ************************************************************************************************************/
@@ -55,7 +55,12 @@ mfaktc 0.07-0.14 to see Luigi's code.
 #include <math.h>
 #include <limits.h>
 #include <ctype.h>
+#include <string.h>
 #include <errno.h>
+
+#ifdef _MSC_VER
+#include <io.h>
+#endif
 
 #include "compatibility.h"
 #include "filelocking.h"
@@ -339,7 +344,7 @@ enum ASSIGNMENT_ERRORS get_next_assignment(char *filename, unsigned int *exponen
  *                                                                                                          *
  *     0 - OK                                                                                               *
  *     3 - clear_assignment    : cannot open file <filename>                                                *
- *     4 - clear_assignment    : cannot open file "__worktodo__.tmp"                                        *
+ *     4 - clear_assignment    : cannot open temp file from template "__worktodo__.XXXXXX"                  *
  *     5 - clear_assignment    : assignment not found                                                       *
  *     6 - clear_assignment    : cannot rename temporary workfile to regular workfile                       *
  *                                                                                                          *
@@ -356,12 +361,15 @@ enum ASSIGNMENT_ERRORS clear_assignment(char *filename, unsigned int exponent, i
   unsigned int line_to_drop = UINT_MAX;
   unsigned int current_line;
   struct ASSIGNMENT assignment;	// the found assignment....
+  char temp_file_template[] = "__worktodo__.XXXXXX";
 
   f_in = fopen_and_lock(filename, "r");
   if (NULL == f_in)
     return CANT_OPEN_WORKFILE;
 
-  f_out = fopen("__worktodo__.tmp", "w");
+  if (make_temp_file(temp_file_template) == 0)
+    f_out = fopen(temp_file_template, "w");
+
   if (NULL == f_out)
   {
     unlock_and_fclose(f_in);
@@ -448,7 +456,7 @@ enum ASSIGNMENT_ERRORS clear_assignment(char *filename, unsigned int exponent, i
     return ASSIGNMENT_NOT_FOUND;
   if(remove(filename) != 0)
     return CANT_RENAME;
-  if(rename("__worktodo__.tmp", filename) != 0)
+  if(rename(temp_file_template, filename) != 0)
     return CANT_RENAME;
   return OK;
 }

--- a/src/parse.c
+++ b/src/parse.c
@@ -411,7 +411,7 @@ enum ASSIGNMENT_ERRORS clear_assignment(char *filename, unsigned int exponent, i
     f_in = fopen_and_lock(filename, "r");
     if (NULL == f_in)
     {
-      unlock_and_fclose(f_out);
+      fclose(f_out);
       f_out = NULL;
       return CANT_OPEN_WORKFILE;
     }


### PR DESCRIPTION
This adds a feature to create a unique random file name for temp files used in `clear_assignment()`, as suggested earlier by @tdulcet (see #53 and #48). I used the more "POSIX-friendly" [_mktemp_s()](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/mktemp-s-wmktemp-s?view=msvc-170) instead of [GetTempFileName()](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettempfilenamew) on Windows. `mkstemp()` is used in non-MSVC environments.

These APIs differ slightly in behavior. `_mktemp_s()` only updates the template to an actual file name, while `mkstemp()` also creates and opens the file for writing. However, it returns a file descriptor as an `int` instead of a `FILE*`. To keep things simple and compatible, I added a `close()` call in the intermediate function `make_temp_file()`, after which the file can be opened with `fopen()` as usual. This nuance should not make any difference for `mfaktc`, but it should be noted and verified for possible issues if ported to `mfakto` (I have not checked that yet).

Perhaps the new function `make_temp_file()` could have a better name. Feel free to suggest or adjust it, as I am short on ideas at the moment. Maybe `prepare_temp_file()`?

There is a small drawback when using random file names. If `mfaktc` exits on error during `clear_assignment()`, the temp file will remain and will not be overwritten and deleted on the next run as it was with the single `__worktodo__.tmp`. This should not normally happen, and I noted in the changelog that such leftover files can be safely deleted, so this approach should be fine.

This PR also fixes a small issue where the temp file was passed to `unlock_and_fclose()` even though it was not locked on open, eliminating the warning "File was not locked!" on each completed assignment.
