### PR TITLE
revert change to print additional details when a factor is found

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -437,7 +437,7 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
 // Prints JSON string to the jsonresultfile for Mersenne numbers as well.
 {
     char UID[110]; /* 50 (V5UserID) + 50 (ComputerID) + 8 + spare */
-    int string_length = 0, factors_list_length = 0, factors_quote_list_length = 0, checksum, json_checksum;
+    int string_length = 0, factors_list_length = 0, factors_quote_list_length = 0, json_checksum;
     char aidjson[MAX_LINE_LENGTH + 11];
     char userjson[62]; /* 50 (V5UserID) + 11 spare + null character */
     char computerjson[66]; /* 50 (ComputerID) + 15 spare + null character */
@@ -546,9 +546,6 @@ void print_result_line(mystuff_t *mystuff, int factorsfound)
     sprintf(details, "CUDA %d.%d arch %d.%d", cuda_major, cuda_minor, arch_major, arch_minor);
 
     string_length += sprintf(txtstring + string_length, " [mfaktc %s %s %s]", MFAKTC_VERSION, mystuff->stats.kernelname, details);
-
-    checksum = crc32_checksum(txtstring, string_length);
-    sprintf(txtstring + string_length, " CRC32: %08X", checksum);
 #ifndef WAGSTAFF
     snprintf(json_checksum_string, sizeof(json_checksum_string), "%u;TF;%s;;%d;%d;%u;;;mfaktc;%s;%s;%s;%s;%s;%s", mystuff->exponent,
              factors_list, mystuff->bit_min, mystuff->bit_max_stage, !partialresult, MFAKTC_VERSION, mystuff->stats.kernelname, details,


### PR DESCRIPTION
mfaktc 0.24.0 prints additional details when a factor is found:

```
Using GPU kernel "barrett76_mul32_gs"
Date Time | class Pct | time ETA | GHz-d/day Sieve Wait
Sep 13 21:35 | 1704 36.8% | 0.033 n.a. | 3221.43 82485 n.a.%
M50611609 has a factor: 461777988770746474633 [TF:68:69:mfaktc 0.24.0-beta.6 barrett76_mul32_gs CUDA 13.0 arch 8.9] 3FBD0F3A
Sep 13 21:36 | 4364 94.4% | 0.034 n.a. | 3126.68 82485 n.a.%
M50611609 has a factor: 355306953811372315433 [TF:68:69:mfaktc 0.24.0-beta.6 barrett76_mul32_gs CUDA 13.0 arch 8.9] 5548429D
Sep 13 21:36 | 4619 100.0% | 0.035 n.a. | 3037.35 82485 n.a.%
found 2 factors for M50611609 from 2^68 to 2^69 [mfaktc 0.24.0-beta.6 barrett76_mul32_gs CUDA 13.0 arch 8.9] 11E309A0
```

However, this adds unnecessary clutter because this information is already optionally recorded in the `results.txt` file, and the PrimeNet server now only looks at the JSON output for the final assignment results. This change reverts the output to a simpler version: https://mersenneforum.org/node/9313?p=1087378#post1087378

Additional changes:

* renamed the variable `string` to be more descriptive
* ~~checksums are now prepended with "CRC32: " in the output and `results.txt`~~ removed the unused checksum for the standard output
* removed an extra space from the "found [x] factors" line
* fixed a grammar issue in `print_factors()`