### PR TITLE
[0.23] General improvements (2025-09-27)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -11,6 +11,11 @@ new features:
 
 enhancements:
 - improved program output in various places
+- getOSJSON() has been made more robust
+
+other changes:
+- macOS is now detected as "macOS" rather than the kernel name "Darwin"
+  - note: mfaktc is not currently supported on macOS
 
 version 0.23.6
 ==============================

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -1,6 +1,6 @@
 /*
 This file is part of mfaktc.
-Copyright (C) 2009, 2010, 2011, 2013  Oliver Weihe (o.weihe@t-online.de)
+Copyright (c) 2009-2011, 2013  Oliver Weihe (o.weihe@t-online.de)
 
 mfaktc is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -54,7 +54,7 @@ checkpoint_write() writes the checkpoint file.
 
     f = fopen(filename, "w");
     if (f == NULL) {
-        printf("WARNING, could not write checkpoint file \"%s\"\n", filename);
+        printf("Warning: could not write checkpoint file \"%s\"\n", filename);
     } else {
         sprintf(buffer, "%s%u %d %d %d %s: %d %d %s %llu", NAME_NUMBERS, exp, bit_min, bit_max, NUM_CLASSES, MFAKTC_VERSION, cur_class,
                 num_factors, strlen(factors_string) ? factors_string : "0", bit_level_time);
@@ -131,7 +131,7 @@ tries to delete the checkpoint file
     if (remove(filename)) {
         if (errno != ENOENT) /* ENOENT = "No such file or directory" -> there was no checkpoint file */
         {
-            printf("WARNING: can't delete the checkpoint file \"%s\"\n", filename);
+            printf("Warning: can't delete the checkpoint file \"%s\"\n", filename);
         }
     }
 }

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -1,6 +1,6 @@
 /*
 This file is part of mfaktc.
-Copyright (C) 2009-2015  Oliver Weihe (o.weihe@t-online.de)
+Copyright (c) 2009-2015  Oliver Weihe (o.weihe@t-online.de)
 
 mfaktc is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -852,12 +852,12 @@ int main(int argc, char **argv)
             i++;
 
             if (tmp > 3) {
-                logprintf(&mystuff, "WARNING: maximum verbosity level is 3\n");
+                logprintf(&mystuff, "Warning: maximum verbosity level is 3\n");
                 tmp = 3;
             }
 
             if (tmp < 0) {
-                logprintf(&mystuff, "WARNING: minimum verbosity level is 0\n");
+                logprintf(&mystuff, "Warning: minimum verbosity level is 0\n");
                 tmp = 0;
             }
 

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -302,8 +302,8 @@ see benchmarks in src/kernel_benchmarks.txt */
             logprintf(mystuff, "\nfound a valid checkpoint file!\n");
             if (mystuff->verbosity >= 1) logprintf(mystuff, "  last finished class was: %d\n", cur_class);
             if (mystuff->verbosity >= 1)
-                logprintf(mystuff, "  found %d factor(s) already%s%s\n", factorsfound, factorsfound > 0 ? ": " : "",
-                          mystuff->factors_string);
+                logprintf(mystuff, "  found %d factor%s so far%s%s\n", factorsfound, factorsfound == 1 ? "" : "s",
+                          factorsfound > 0 ? ": " : "", mystuff->factors_string);
             if (mystuff->verbosity >= 1)
                 logprintf(mystuff, "  previous work took %llu ms\n\n", mystuff->stats.bit_level_time);
             else

--- a/src/mfaktc.ini
+++ b/src/mfaktc.ini
@@ -208,7 +208,7 @@ ResultsFileTimestampInterval=1
 #  %p - percent complete (%)           "%5.1f"
 #  %g - GHz-days/day (GHz)             "%8.2f"
 #  %t - time per class (s)             "%6.0f" / "%6.1f" / "%6.2f" / "%6.3f"
-#  %e - eta (d/h/m/s)                  "%2dm%02ds" / "%2dh%02dm" / "%2dd%02dh"
+#  %e - ETA (d/h/m/s)                  "%2dm%02ds" / "%2dh%02dm" / "%2dd%02dh"
 #  %E - elapsed (d/h/m/s)              "%2dm%02ds" / "%2dh%02dm" / "%2dd%02dh"
 #  %n - number of candidates (M/G)     "%6.2fM"/"%6.2fG"
 #  %r - rate (M/s)                     "%6.2f" / "%6.1f"
@@ -240,7 +240,7 @@ ProgressFormat=%d %T | %C %p%% | %t  %e |  %g  %s  %W%%
 #ProgressFormat=%C/4620 |    %n | %ts | %e | %rM/s |     %s |  %W%%
 
 # print everything
-#ProgressHeader=[date    time]  exponent [TF bits]: percent  class #, seq    |     GHZ |    time |    ETA |    #FCs |      rate | SieveP. | CPU wait | V5UserID@ComputerID
+#ProgressHeader=[date    time]  exponent [TF bits]: percent  class #, seq    |     GHz |    time |    ETA |    #FCs |      rate | SieveP. | CPU wait | V5UserID@ComputerID
 #ProgressFormat=[%d %T] M%M [%l-%u]: %p%% %C/4620,%c/960 | %g | %ts | %e | %n | %rM/s | %s |  %W%% | %U@%H
 
 

--- a/src/my_types.h
+++ b/src/my_types.h
@@ -129,8 +129,8 @@ typedef struct
 
     stats_t stats; /* stuff for statistics, etc. */
 
-    char V5UserID[51]; /* primenet V5UserID and ComputerID */
-    char ComputerID[51]; /* currently only used for screen/result output */
+    char V5UserID[51]; /* PrimeNet user ID and computer ID */
+    char ComputerID[51];
     char assignment_key[MAX_LINE_LENGTH + 1]; /* the assignment ID */
     char factors_string[500]; /* store factors in global state */
 

--- a/src/output.c
+++ b/src/output.c
@@ -387,19 +387,6 @@ void get_utc_timestamp(char *timestamp)
     strftime(timestamp, sizeof(char[50]), "%Y-%m-%d %H:%M:%S", utc_time);
 }
 
-const char *getArchitectureJSON()
-{
-#if defined(__x86_64__) || defined(_M_X64)
-    return ", \"architecture\": \"x86_64\"";
-#elif defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
-    return ", \"architecture\": \"x86_32\"";
-#elif defined(__aarch64__) || defined(_M_ARM64)
-    return ", \"architecture\": \"ARM64\"";
-#else
-    return "";
-#endif
-}
-
 const char *getArchitecture()
 {
 #if defined(__x86_64__) || defined(_M_X64)

--- a/src/output.c
+++ b/src/output.c
@@ -400,17 +400,35 @@ const char *getArchitectureJSON()
 #endif
 }
 
-void getOSJSON(char *string)
+const char *getArchitecture()
+{
+#if defined(__x86_64__) || defined(_M_X64)
+    return "x86_64";
+#elif defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+    return "x86_32";
+#elif defined(__aarch64__) || defined(_M_ARM64)
+    return "ARM64";
+#else
+    return "";
+#endif
+}
+
+const char *getOS()
 {
 #if defined(_WIN32) || defined(_WIN64)
-    sprintf(string, ", \"os\":{\"os\": \"Windows\"%s}", getArchitectureJSON());
+    return "Windows";
 #elif defined(__APPLE__)
-    sprintf(string, ", \"os\":{\"os\": \"Darwin\"%s}", getArchitectureJSON());
+    return "macOS";
 #elif defined(__linux__)
-    sprintf(string, ", \"os\":{\"os\": \"Linux\"%s}", getArchitectureJSON());
+    return "Linux";
 #elif defined(__unix__)
-    sprintf(string, ", \"os\":{\"os\": \"Unix\"%s}", getArchitectureJSON());
+    return "Unix";
 #endif
+}
+
+void getOSJSON(char *string)
+{
+    sprintf(string, ", \"os\":{\"os\": \"%s\", \"architecture\": \"%s\"}", getOS(), getArchitecture());
 }
 
 void print_result_line(mystuff_t *mystuff, int factorsfound)


### PR DESCRIPTION
General improvements as follows:
* backported the more robust `getOSJSON()` from mfaktc 0.24.x
* changed warning messages to lowercase for consistency
* updated some outputs to match mfaktc 0.24.x and mfakto 0.16
* macOS is now detected as "macOS" rather than the kernel name "Darwin" (even though macOS currently doesn't support CUDA applications)