### PR TITLE
Release version 0.24.1 (binary-only updates)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,4 +1,8 @@
 
+version 0.24.1
+==============================
+- no codebase changes, binary-only release rebuilt with current CUDA versions
+
 version 0.24.0
 ==============================
 - merged development branches 0.22 and 0.23.x

--- a/src/params.h
+++ b/src/params.h
@@ -90,7 +90,7 @@ Do not update this value until a new release is ready to be created. Please
 discuss with the community before making changes to version numbers!
 */
 
-#define MFAKTC_VERSION            "0.24.0"
+#define MFAKTC_VERSION            "0.24.1"
 #define MFAKTC_CHECKPOINT_VERSION "0.24"
 #define MFAKTC_CHECKSUM_VERSION   1
 


### PR DESCRIPTION
No codebase changes since 0.24.0. However, I think it still makes sense to do a new release because several newer CUDA versions have been released since then. Some of them might provide slight performance improvements on newer GPUs. This release will make prebuilt binaries compiled with those newer CUDA versions available for download.

What do you think?