### PR TITLE
emergency change: temporarily downgrade Windows build runner to `windows-2022`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
     # windows-2022 also works and produces nearly identical binaries, so let's
     # target the image that will be supported in the longer term. windows-2025
     # is in beta as of June 2025, but testing has shown it is reliable.
-    runs-on: windows-2025
+    runs-on: windows-2022
 
     strategy:
       # If set to true, all jobs within the same matrix (such as Linux or


### PR DESCRIPTION
GitHub's [latest changes](https://github.com/actions/runner-images/issues/14017) to the `windows-2025` runner has broken all the Windows builds. This change temporary downgrades the Windows build runner to `windows-2022` while we figure out what's causing the build failures.