### PR TITLE
group Dependabot updates into a single pull request to reduce PR spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,7 +346,7 @@ jobs:
           ( echo "$GITHUB_REF_NAME" | grep -qsP "v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(-(?:alpha|beta|pre))" && echo "PRERELEASE=true" || echo "PRERELEASE=false" ) >> $GITHUB_OUTPUT
 
       - name: Create and upload release package
-        uses: softprops/action-gh-release@v3.0.1
+        uses: softprops/action-gh-release@v3
         with:
           fail_on_unmatched_files: false
           files: |


### PR DESCRIPTION
Dependabot currently creates a separate pull request for each updated action. This change groups the updates into a single PR to reduce spam.

I also changed `softprops/action-gh-release` from `v3.0.1` to just `v3` so that the runner always uses the latest available version (at least until `v4` comes out).