### PR TITLE
Added separate CI and CD workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,26 +17,12 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-name: mfaktc CI
+name: mfaktc CD
 
 on:
   push:
-    paths-ignore:
-      - '**/*.txt'
-      - '**/*.ini'
-      - 'COPYING'
-      - '.gitignore'
-  pull_request:
-    paths-ignore:
-      - '**/*.txt'
-      - '**/*.ini'
-      - 'COPYING'
-      - '.gitignore'
-    types:
-      - 'opened'
-      - 'reopened'
-      - 'synchronize'
-      - 'ready_for_review'
+    tags:
+      - '*'
   workflow_dispatch:
 
 jobs:
@@ -50,90 +36,77 @@ jobs:
       fail-fast: false
 
       matrix:
-        sys:
-          # Specified version combination must exist as CUDA container image from Nvidia: nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}
-          # Available versions can be found here: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags (note that only Ubuntu distros are supported by this action)
-          - { cuda_version: '13.2.1', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '13.2.0', ct_os: 'ubuntu24.04' }
-          - { cuda_version: '13.1.2', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '13.1.1', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '13.1.0', ct_os: 'ubuntu24.04' }
-          - { cuda_version: '13.0.3', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '13.0.2', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '13.0.1', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '13.0.0', ct_os: 'ubuntu24.04' }
-          - { cuda_version: '12.9.2', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '12.9.1', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '12.9.0', ct_os: 'ubuntu24.04' }
-          - { cuda_version: '12.8.2', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '12.8.1', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '12.8.0', ct_os: 'ubuntu24.04' }
-          - { cuda_version: '12.6.3', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '12.6.2', ct_os: 'ubuntu22.04' }
-          # - { cuda_version: '12.6.1', ct_os: 'ubuntu22.04' }
-          # - { cuda_version: '12.6.0', ct_os: 'ubuntu22.04' }
-          - { cuda_version: '12.5.1', ct_os: 'ubuntu24.04' }
-          # - { cuda_version: '12.5.0', ct_os: 'ubuntu22.04' }
-          - { cuda_version: '12.4.1', ct_os: 'ubuntu22.04' }
-          # - { cuda_version: '12.4.0', ct_os: 'ubuntu22.04' }
-          - { cuda_version: '12.3.2', ct_os: 'ubuntu22.04' }
-          # - { cuda_version: '12.3.1', ct_os: 'ubuntu22.04' }
-          # - { cuda_version: '12.3.0', ct_os: 'ubuntu22.04' }
-          - { cuda_version: '12.2.2', ct_os: 'ubuntu22.04' }
-          # - { cuda_version: '12.2.0', ct_os: 'ubuntu22.04' }
-          - { cuda_version: '12.1.1', ct_os: 'ubuntu22.04' }
-          # - { cuda_version: '12.1.0', ct_os: 'ubuntu22.04' }
-          - { cuda_version: '12.0.1', ct_os: 'ubuntu22.04' }
-          # - { cuda_version: '12.0.0', ct_os: 'ubuntu22.04' }
-          - { cuda_version: '11.8.0', ct_os: 'ubuntu22.04' }
-          - { cuda_version: '11.7.1', ct_os: 'ubuntu22.04' }
-          # - { cuda_version: '11.7.0', ct_os: 'ubuntu22.04' }
-          - { cuda_version: '11.6.2', ct_os: 'ubuntu20.04' }
-          # - { cuda_version: '11.6.1', ct_os: 'ubuntu20.04' }
-          # - { cuda_version: '11.6.0', ct_os: 'ubuntu20.04' }
-          - { cuda_version: '11.5.2', ct_os: 'ubuntu20.04' }
-          # - { cuda_version: '11.5.1', ct_os: 'ubuntu20.04' }
-          # - { cuda_version: '11.5.0', ct_os: 'ubuntu20.04' }
-          - { cuda_version: '11.4.3', ct_os: 'ubuntu20.04' }
-          - { cuda_version: '11.3.1', ct_os: 'ubuntu20.04' }
-          - { cuda_version: '11.2.2', ct_os: 'ubuntu20.04' }
-          - { cuda_version: '11.1.1', ct_os: 'ubuntu20.04' }
-          - { cuda_version: '11.0.3', ct_os: 'ubuntu20.04' }
-          - { cuda_version: '10.2', ct_os: 'ubuntu18.04' }
-          - { cuda_version: '9.2', ct_os: 'ubuntu18.04' }
-          - { cuda_version: '8.0', ct_os: 'ubuntu16.04' }
+        include:
+          # Specified version combination must exist as CUDA container image from Nvidia: nvcr.io/nvidia/cuda:${{ matrix.cuda_version }}-devel-${{ matrix.ct_os }}
+          # Available versions can be found here: https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags
 
-    env:
+          # Rocky Linux 8: glibc 2.28
+          - { cuda_version: '13.2.1', ct_os: 'rockylinux8', toolset: 'system' }
+          - { cuda_version: '13.1.2', ct_os: 'rockylinux8', toolset: 'system' }
+          - { cuda_version: '13.0.3', ct_os: 'rockylinux8', toolset: 'system' }
+          - { cuda_version: '12.9.2', ct_os: 'rockylinux8', toolset: 'system' }
+          - { cuda_version: '12.8.2', ct_os: 'rockylinux8', toolset: 'system' }
+          - { cuda_version: '12.6.3', ct_os: 'rockylinux8', toolset: 'system' }
+          - { cuda_version: '12.5.1', ct_os: 'rockylinux8', toolset: 'system' }
+          - { cuda_version: '12.4.1', ct_os: 'rockylinux8', toolset: 'system' }
+
+          # CentOS 7 with GCC 6: glibc 2.17
+          - { cuda_version: '12.3.2', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '12.2.2', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '12.1.1', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '12.0.1', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '11.8.0', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '11.7.1', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '11.6.2', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '11.5.2', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '11.4.3', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '11.3.1', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '11.2.2', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '11.1.1', ct_os: 'centos7', toolset: '6' }
+          - { cuda_version: '11.0.3', ct_os: 'centos7', toolset: '6' }
+
+          # CentOS 7 system GCC 4.8: glibc 2.17
+          - { cuda_version: '10.2', ct_os: 'centos7', toolset: 'system' }
+          - { cuda_version: '9.2',  ct_os: 'centos7', toolset: 'system' }
+          - { cuda_version: '8.0',  ct_os: 'centos7', toolset: 'system' }
+
       # We can't use GitHub direct container support on old Ubuntu versions,
       # because actions will fail due to an old glibc version.
       # A workaround is to use 'docker exec' to run build-related actions in
       # a separately launched Docker container, while generic actions will run
       # on the host runner.
-      CONTAINER: "nvcr.io/nvidia/cuda:${{ matrix.sys.cuda_version }}-devel-${{ matrix.sys.ct_os }}"
 
     steps:
 
       - name: Start Docker container
         run: |
-          docker pull $CONTAINER
-          docker run --name build-container -d -v ${GITHUB_WORKSPACE}:/workspace $CONTAINER tail -f /dev/null
-
-      - name: Update GPG keys for CUDA repo on Ubuntu 16.04
-        if: matrix.sys.ct_os == 'ubuntu16.04'
-        env:
-          SCRIPT: apt-key add /workspace/3bf863cc.pub
-        run: |
-          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub
-          docker exec build-container bash -c "$SCRIPT"
+          docker run --rm --name build-container -d -v "${GITHUB_WORKSPACE}:/workspace" "nvcr.io/nvidia/cuda:${{ matrix.cuda_version }}-devel-${{ matrix.ct_os }}" tail -f /dev/null
 
       - name: Update and install dependencies inside container
         id: packages
-        env:
-          SCRIPT: |
-            apt-get update
-            apt-get -y full-upgrade
-            apt-get install -y build-essential curl git make python3 sudo unzip wget zip
-        run: docker exec build-container bash -c "$SCRIPT"
+        run: |
+          docker exec -i -w /workspace build-container bash -s <<'EOF'
+            set -e -o pipefail
+            if [[ "${{ matrix.ct_os }}" == centos* ]]; then
+              sed -i '/^mirrorlist/d;/^#baseurl=/{s|^#||;s|/mirror|/vault|;}' /etc/yum.repos.d/CentOS*.repo
+              # yum update -y
+              if [[ "${{ matrix.toolset }}" == system ]]; then
+                yum install -y gcc gcc-c++ make git zip
+              else
+                yum install -y centos-release-scl
+                sed -i 's|/centos/7/|/centos/7.6.1810/|g;/^mirrorlist/d;/^# *baseurl=/{s|^# *||;s|/mirror|/vault|;}' /etc/yum.repos.d/CentOS-SCLo-*.repo
+                yum install -y "devtoolset-${{ matrix.toolset }}-gcc-c++" make git zip
+                source "/opt/rh/devtoolset-${{ matrix.toolset }}/enable"
+              fi
+            else
+              # dnf update -y
+              dnf install -y gcc gcc-c++ make git zip
+            fi
+
+            gcc --version
+            ldd --version
+            nvcc --version
+          EOF
 
       - name: Checkout repo
         uses: actions/checkout@v7
@@ -143,35 +116,47 @@ jobs:
 
       - name: Prepare sources and gather info
         id: prepare
-        env:
-          SCRIPT: |
-            cd /workspace
-            git config --global --add safe.directory /workspace
-            bash .github/workflows/scripts/build_helper.sh ${{ matrix.sys.cuda_version }}
         run: |
-          docker exec build-container bash -c "$SCRIPT"
-          cat .github/workflows/scripts/build_helper.sh.out >> $GITHUB_OUTPUT
+          docker exec -i -w /workspace build-container bash -s <<'EOF'
+            set -e -o pipefail
+            if [[ "${{ matrix.toolset }}" != system ]]; then
+              source "/opt/rh/devtoolset-${{ matrix.toolset }}/enable"
+            fi
+            git config --global --add safe.directory /workspace
+            bash .github/workflows/scripts/build_helper.sh ${{ matrix.cuda_version }}
+          EOF
+          cat .github/workflows/scripts/build_helper.sh.out >> "$GITHUB_OUTPUT"
 
       - name: Build from sources
-        env:
-          SCRIPT: cd /workspace/src && make -j$(nproc)
-        run: docker exec build-container bash -c "$SCRIPT"
+        run: |
+          docker exec -i -w /workspace build-container bash -s <<'EOF'
+            set -e -o pipefail
+            if [[ "${{ matrix.toolset }}" != system ]]; then
+              source "/opt/rh/devtoolset-${{ matrix.toolset }}/enable"
+            fi
+            cd src
+            make -j$(nproc)
+          EOF
 
       - name: Prepare ZIP archive with description
-        env:
-          SCRIPT: |
-            cd /workspace
+        run: |
+          docker exec -i -w /workspace build-container bash -s <<'EOF'
+            set -e -o pipefail
             zip -9 -j ${{ steps.prepare.outputs.BASE_NAME }}.zip Changelog.txt COPYING mfaktc mfaktc.ini README.txt
             echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
-            ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
+            ${{ matrix.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
             ${{ steps.prepare.outputs.COMPILER_VER }} | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
-        run: docker exec build-container bash -c "$SCRIPT"
+          EOF
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.prepare.outputs.BASE_NAME }}
           path: ${{ steps.prepare.outputs.BASE_NAME }}.*
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f build-container || true
 # End job "build-linux"
 
 # Begin job "build-win"
@@ -189,31 +174,31 @@ jobs:
       matrix:
         # Available CUDA versions can be viewed at the Jimver/cuda-toolkit action sources:
         # https://github.com/N-Storm/cuda-toolkit/blob/v0.2.31/src/links/windows-links.ts
-        sys:
-          - { cuda_version: '13.2.1' }
-          - { cuda_version: '13.1.2' }
-          - { cuda_version: '13.0.3' }
-          - { cuda_version: '12.9.2' }
-          - { cuda_version: '12.8.2' }
-          - { cuda_version: '12.6.3' }
-          - { cuda_version: '12.5.1' }
-          - { cuda_version: '12.4.1' }
-          - { cuda_version: '12.3.2' }
-          - { cuda_version: '12.2.2' }
-          - { cuda_version: '12.1.1' }
-          - { cuda_version: '12.0.1' }
-          - { cuda_version: '11.8.0' }
-          - { cuda_version: '11.7.1' }
-          - { cuda_version: '11.6.2' }
-          - { cuda_version: '11.5.2' }
-          - { cuda_version: '11.4.4' }
-          - { cuda_version: '11.3.1' }
-          - { cuda_version: '11.2.2' }
-          - { cuda_version: '11.1.1' }
-          - { cuda_version: '11.0.1' }
-          - { cuda_version: '10.0.130' }
-          - { cuda_version: '9.2.148' }
-          - { cuda_version: '8.0.61' }
+        cuda_version:
+          - '13.2.1'
+          - '13.1.2'
+          - '13.0.3'
+          - '12.9.2'
+          - '12.8.2'
+          - '12.6.3'
+          - '12.5.1'
+          - '12.4.1'
+          - '12.3.2'
+          - '12.2.2'
+          - '12.1.1'
+          - '12.0.1'
+          - '11.8.0'
+          - '11.7.1'
+          - '11.6.2'
+          - '11.5.2'
+          - '11.4.4'
+          - '11.3.1'
+          - '11.2.2'
+          - '11.1.1'
+          - '11.0.1'
+          - '10.0.130'
+          - '9.2.148'
+          - '8.0.61'
 
     env:
       MSVC_PKG_VC140: Microsoft.VisualStudio.Component.VC.140
@@ -232,30 +217,28 @@ jobs:
         id: cuda-toolkit
         uses: N-Storm/cuda-toolkit@v0.2.34
         with:
-          cuda: ${{ matrix.sys.cuda_version }}
-          sub-packages: ${{ startsWith(matrix.sys.cuda_version, '8.') && '[]' || startsWith(matrix.sys.cuda_version, '13.') &&'[ "nvcc", "crt", "cudart", "nvvm", "nvptxcompiler" ]' || '[ "nvcc", "cudart" ]' }}
+          cuda: ${{ matrix.cuda_version }}
+          sub-packages: ${{ startsWith(matrix.cuda_version, '8.') && '[]' || startsWith(matrix.cuda_version, '13.') &&'[ "nvcc", "crt", "cudart", "nvvm", "nvptxcompiler" ]' || '[ "nvcc", "cudart" ]' }}
           use-local-cache: false
           use-github-cache: false
-
-      - name: Configure path to CUDA
-        shell: powershell
-        run: |
-          [System.Environment]::SetEnvironmentVariable('PATH', "$env:CUDA_PATH\bin;$env:PATH", 'User')
 
       - name: Prepare sources and gather info
         id: prepare
         shell: bash
         run: |
-          bash .github/workflows/scripts/build_helper.sh ${{ matrix.sys.cuda_version }}
-          cat .github/workflows/scripts/build_helper.sh.out >> $GITHUB_OUTPUT
+          bash .github/workflows/scripts/build_helper.sh ${{ matrix.cuda_version }}
+          cat .github/workflows/scripts/build_helper.sh.out >> "$GITHUB_OUTPUT"
 
       - name: Build from sources with MSVC
         shell: cmd
         run: |
-          ${{ env.MSVC_ADD_PKG_CMD }}
-          "${{ env.VCVARS_PATH }}" x64 ${{ env.VCVARS_VER }} & cd src & copy mfaktc.ini .. & make SHELL="cmd.exe" -j%NUMBER_OF_PROCESSORS% -f Makefile.win & cl /? 2>&1 | findstr /C:"Version" > clversion.log & echo Build finished
+          ${{ env.MSVC_ADD_PKG_CMD }} || exit /b 1
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" ${{ env.VCVARS_VER }} || exit /b 1
+          cd src || exit /b 1
+          copy mfaktc.ini .. || exit /b 1
+          make SHELL="cmd.exe" -j%NUMBER_OF_PROCESSORS% -f Makefile.win || exit /b 1
+          cl /? 2>&1 | findstr /C:"Version" > clversion.log || exit /b 1
         env:
-          VCVARS_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat'
           # vcvars_ver=14.x enables Build Tools for previous MSVC versions:
           # - 14.0 is for Visual Studio 2015
           # - 14.16 is for Visual Studio 2017 version 15.9.x
@@ -289,11 +272,11 @@ jobs:
         # during the build step. Here, the cl version is extracted and added to
         # the table along with the MSVC version.
         run: |
-          [ -f src/clversion.log ] && CL_VER="$(grep -Eoe 'Version [\.0-9]+ ' src/clversion.log | cut -d' ' -f2)"
-          [ -z "$CL_VER" ] && CL_VER='Unknown'
+          [[ -f src/clversion.log ]] && CL_VER="$(grep -Eoe 'Version [\.0-9]+ ' src/clversion.log | cut -d' ' -f2)"
+          [[ -z "$CL_VER" ]] && CL_VER='Unknown'
           7z a -tzip -mx=9 "${{ steps.prepare.outputs.BASE_NAME }}.zip" Changelog.txt COPYING mfaktc-win-64.exe mfaktc.ini README.txt
           echo "[${{ steps.prepare.outputs.BASE_NAME }}.zip](https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/${{ steps.prepare.outputs.BASE_NAME }}.zip) | \
-          ${{ matrix.sys.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
+          ${{ matrix.cuda_version }} | ${{ steps.prepare.outputs.CC_MIN }}-${{ steps.prepare.outputs.CC_MAX }} | ${{ steps.prepare.outputs.OS_VER }} | \
           ${CL_VER} (${{ steps.prepare.outputs.COMPILER_VER }}) | ${{ steps.prepare.outputs.NVCC_VER }}" > ${{ steps.prepare.outputs.BASE_NAME }}.txt
 
       - name: Upload build artifacts
@@ -342,8 +325,8 @@ jobs:
             echo 'RELEASE_FILES<<EOF'
             printf '%s\n' "${base_name}.zip" | sort -Vr
             echo 'EOF'
-          } > $GITHUB_OUTPUT
-          ( echo "$GITHUB_REF_NAME" | grep -qsP "v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(-(?:alpha|beta|pre))" && echo "PRERELEASE=true" || echo "PRERELEASE=false" ) >> $GITHUB_OUTPUT
+          } > "$GITHUB_OUTPUT"
+          ( echo "$GITHUB_REF_NAME" | grep -qsP "v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(-(?:alpha|beta|pre))" && echo "PRERELEASE=true" || echo "PRERELEASE=false" ) >> "$GITHUB_OUTPUT"
 
       - name: Create and upload release package
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,142 @@
+# This file is part of mfaktc.
+# Copyright (c) 2025        NStorm (https://github.com/N-Storm)
+# Copyright (c) 2009-2011   Oliver Weihe (o.weihe@t-online.de)
+#
+# mfaktc is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# mfaktc is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+name: mfaktc CI
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.txt'
+      - '**/*.ini'
+      - 'COPYING'
+      - '.gitignore'
+  pull_request:
+    paths-ignore:
+      - '**/*.txt'
+      - '**/*.ini'
+      - 'COPYING'
+      - '.gitignore'
+    types:
+      - 'opened'
+      - 'reopened'
+      - 'synchronize'
+      - 'ready_for_review'
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+# Begin job "Linux"
+  Linux:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # If set to true, all jobs within the same matrix (such as Linux or
+      # Windows builds) will be aborted at the same time if any one job fails.
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
+        cc: [gcc, clang]
+
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cc == 'gcc' && 'g++' || 'clang++' }}
+
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Update and install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nvidia-cuda-toolkit
+
+      - name: Prepare sources
+        run: |
+          cuda_version=$(nvcc --version | awk '/release/ { sub(/^V/, "", $NF); print $NF }')
+          bash .github/workflows/scripts/build_helper.sh "$cuda_version"
+
+      - name: Build from sources
+        run: |
+          cd src
+          make -O -j$(nproc) DEBUG=1
+          make clean
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: mfaktc-linux64-${{ matrix.os }}-${{ matrix.cc }}
+          path: ${{ github.workspace }}
+# End job "Linux"
+
+# Begin job "Windows"
+  Windows:
+    # windows-2022 also works and produces nearly identical binaries, so let's
+    # target the image that will be supported in the longer term. windows-2025
+    # is in beta as of June 2025, but testing has shown it is reliable.
+    runs-on: windows-2022
+
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install CUDA Toolkit
+        uses: N-Storm/cuda-toolkit@v0.2.34
+
+      - name: Prepare sources
+        shell: bash
+        run: |
+          cuda_version=$(nvcc --version | awk '/release/ { sub(/^V/, "", $NF); print $NF }')
+          bash .github/workflows/scripts/build_helper.sh "$cuda_version"
+
+      - name: Build from sources with MSVC
+        shell: cmd
+        run: |
+          "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat" x64 || exit /b 1
+          cd src || exit /b 1
+          copy mfaktc.ini .. || exit /b 1
+          make SHELL="cmd.exe" -j%NUMBER_OF_PROCESSORS% -f Makefile.win DEBUG=1 || exit /b 1
+          make clean -f Makefile.win || exit /b 1
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: mfaktc-win64
+          path: ${{ github.workspace }}
+# End job "Windows"
+
+  ShellCheck:
+    name: ShellCheck
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Script
+      run: shopt -s globstar; shellcheck -o avoid-nullary-conditions,check-set-e-suppressed,deprecate-which,quote-safe-variables,require-double-brackets -s bash **/*.sh
+      continue-on-error: true

--- a/.github/workflows/scripts/build_helper.sh
+++ b/.github/workflows/scripts/build_helper.sh
@@ -26,6 +26,8 @@
 # support building under GitHub Actions runner environments and compiling
 # kernels for all devices with NVCC-supported compute capabilities.
 
+set -e -o pipefail
+
 if [[ -z "$1" ]]; then
   echo "Usage: $0 <CUDA version>" >&2
   exit 1
@@ -35,7 +37,7 @@ fi
 # to GNU sort
 export GSORT='/usr/bin/sort'
 
-CUDA_VERSION_FULL="$(echo "$1" | head -n1 | grep -Eom1 -e '^[1-9]([0-9])?\.[0-9]{1,2}(\.[0-9]{1,3})?$')"
+CUDA_VERSION_FULL=$(echo "$1" | head -n1 | grep -Eom1 -e '^[1-9]([0-9])?\.[0-9]{1,2}(\.[0-9]{1,3})?$')
 declare -a CUDA_VERSION
 IFS=" " read -r -a CUDA_VERSION <<< "$(echo "$CUDA_VERSION_FULL" | tr '.' ' ')"
 if [[ -z "${CUDA_VERSION[*]}" ]]; then
@@ -54,18 +56,18 @@ printf -v CUDA_VER %d%02d "${CUDA_VER_MAJOR}" "${CUDA_VER_MINOR}";
 # CUDA supports the --list-gpu-arch flag from 11.0.0 onwards.
 # For older CUDA versions, use grep to parse the supported architectures from
 # the output of --help
-[ "$CUDA_VER" -gt 1100 ] && NVCC_OPTS='--list-gpu-arch' || NVCC_OPTS='--help'
+[[ "$CUDA_VER" -gt 1100 ]] && NVCC_OPTS='--list-gpu-arch' || NVCC_OPTS='--help'
 NVCC_REGEX='compute_[1-9][0-9]{1,2}'
 # CUDA 11.0.x is a special case. Its --help output lists compute_32 and higher,
 # but only compute capability 3.5 and later are supported.
-[ "$CUDA_VER" -eq 1100 ] && NVCC_REGEX='compute_(3[5-9]|[4-9][0-9])'
+[[ "$CUDA_VER" -eq 1100 ]] && NVCC_REGEX='compute_(3[5-9]|[4-9][0-9])'
 
 declare -a CC_LIST
 IFS=" " read -r -a CC_LIST <<< "$(nvcc "$NVCC_OPTS" | grep -Eoe "$NVCC_REGEX" | cut -d '_' -f2 | $GSORT -un | xargs)"
-if [ ${#CC_LIST[*]} -eq 0 ]; then
+if [[ ${#CC_LIST[*]} -eq 0 ]]; then
   echo "Error: could not parse list of supported compute capabilities" >&2
   exit 3
-elif [ ${#CC_LIST[*]} -lt 3 ]; then
+elif [[ ${#CC_LIST[*]} -lt 3 ]]; then
   echo "Warning: less than three (3) supported compute capabilities" >&2
 fi
 
@@ -80,46 +82,42 @@ for CC in "${CC_LIST[@]}"; do
   sed -i "/^NVCCFLAGS = .*\$/a NVCCFLAGS += --generate-code arch=compute_${CC},code=sm_${CC}" src/Makefile src/Makefile.win
 done
 
-if [ "$CUDA_VER" -ge 1100 ]; then
+if [[ "$CUDA_VER" -ge 1100 ]]; then
   echo 'Adding NVCCFLAGS to allow unsupported MSVC versions...'
   sed -i '/^NVCCFLAGS = .*/a NVCCFLAGS += -allow-unsupported-compiler -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH' src/Makefile.win
-fi
-if [ "$CUDA_VER" -lt 1200 ]; then
-  echo "Adding libraries to LDFLAGS to support static build on older Ubuntu versions..."
-  sed -i -E 's/^(LDFLAGS = .*? -lcudart_static) (.*)/\1 -ldl -lrt -lpthread \2/' src/Makefile
 fi
 
 echo 'Gathering host compiler and NVCC version info...'
 # COMPILER_VER for Windows builds is actually set to the MSVC product version.
 # We retrieve the cl.exe version during the build step and add it to the table.
 if [[ -x "$(command -v vswhere.exe)" ]]; then
-  CC_VSPROD="$(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property displayName | sed -e 's/Visual Studio/MSVC/')"
+  CC_VSPROD=$(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property displayName | sed -e 's/Visual Studio/MSVC/')
   COMPILER_VER="${CC_VSPROD}, $(vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationVersion)"
 elif [[ -x "$(command -v powershell.exe)" ]]; then
-  CC_VSINFO="$(powershell -Command Get-VSSetupInstance)"
-  CC_VSPROD="$(echo "$CC_VSINFO" | grep DisplayName | cut -d':' -f2 | xargs | sed -e 's/Visual Studio/MSVC/')"
+  CC_VSINFO=$(powershell -Command Get-VSSetupInstance)
+  CC_VSPROD=$(echo "$CC_VSINFO" | grep DisplayName | cut -d':' -f2 | xargs | sed -e 's/Visual Studio/MSVC/')
   COMPILER_VER="${CC_VSPROD}, $(echo "$CC_VSINFO" | grep InstallationVersion | cut -d':' -f2 | xargs)"
 else
-  COMPILER_VER="$(gcc --version | head -n1)"
+  COMPILER_VER=$(gcc --version | head -n1)
   # shellcheck source=/dev/null
   source /etc/os-release
-  OS_VER="${PRETTY_NAME}"
+  OS_VER=${PRETTY_NAME}
   OS_TYPE="linux64"
 fi
 
 if [[ -x "$(command -v powershell.exe)" ]]; then
-  OS_VER="$(powershell -Command "[System.Environment]::OSVersion.VersionString" | cut -d ' ' -f2-)"
+  OS_VER=$(powershell -Command "[System.Environment]::OSVersion.VersionString" | cut -d ' ' -f2-)
   OS_TYPE="win64"
 fi
 
-NVCC_VER="$(nvcc --version | tail -n1 | sed -E 's/^Build //;s/^Cuda compilation tools, //')"
+NVCC_VER=$(nvcc --version | tail -n1 | sed -E 's/^Build //;s/^Cuda compilation tools, //')
 
 # get mfaktc version from src/params.h
 # match SemVer and GIMPS version strings: https://regex101.com/r/m38d3i/2
-MFAKTC_VER="$(LC_ALL=en_US.utf8 grep -iPo '#define[\s\t]+MFAKTC_VERSION[\s\t]+"v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(?:-?(?:alpha|beta|pre)\.?(?:\d+)?\b)?' src/params.h | cut -d '"' -f 2)"
+MFAKTC_VER=$(LC_ALL=en_US.utf8 grep -iPo '#define[\s\t]+MFAKTC_VERSION[\s\t]+"v?\d+(?:\.\d+(?:\.\d+)?(?:-\d+)?|\b)(?:-?(?:alpha|beta|pre)\.?(?:\d+)?\b)?' src/params.h | cut -d '"' -f 2)
 
 # Git-formatted version
-GIT_TAG_VER="$(git describe --tags)"
+GIT_TAG_VER=$(git describe --tags)
 
 # Compare MFAKTC_VER with the version extracted from GIT_TAG_VER using tags.
 # If they don't match, throw a warning and use MFAKTC_VER and the short commit
@@ -130,7 +128,7 @@ GIT_TAG_VER="$(git describe --tags)"
 # reference. This gives a shorter BASE_NAME without the commit hash for
 # releases.
 if [[ "$MFAKTC_VER" != "${GIT_TAG_VER:0:${#MFAKTC_VER}}" ]]; then
-  SHA_SHORT="$(git rev-parse --short HEAD)"
+  SHA_SHORT=$(git rev-parse --short HEAD)
   BASE_NAME="mfaktc-${MFAKTC_VER}-${SHA_SHORT}-${OS_TYPE}-cuda${CUDA_VERSION_FULL}"
   echo "Warning: version from 'git describe' (${GIT_TAG_VER}) doesn't begin with MFAKTC_VER (${MFAKTC_VER}) from params.h"
   echo "Using version from params.h and short commit hash (${SHA_SHORT}) for BASE_NAME"

--- a/contrib/start-mfaktc.sh
+++ b/contrib/start-mfaktc.sh
@@ -51,16 +51,15 @@ LOCK=$APP.lock
 run_on_device() {
     # ensure instance has its own folder
     mkdir -p "device-$1"
-    if ! cd "device-$1"
-    then
+    if ! cd "device-$1"; then
         echo "error: could not enter directory 'device-$1' for device $1" >&2
         exit 1
     fi
 
     # don't run if device is in use
-    exec 200>"$LOCK"
+    exec {LOCK_FD}>"$LOCK"
 
-    if ! flock -n 200; then
+    if ! flock -n "$LOCK_FD"; then
         echo "error: lock file $LOCK exists, mfaktc may already be running on device $1" >&2
         exit 1
     fi
@@ -105,9 +104,9 @@ fi
 
 if [[ $# -eq 0 ]]; then
     # don't run if device is in use
-    exec 200>"$LOCK"
+    exec {LOCK_FD}>"$LOCK"
 
-    if ! flock -n 200; then
+    if ! flock -n "$LOCK_FD"; then
         echo "error: lock file $LOCK exists, mfaktc may already be running" >&2
         exit 1
     fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,14 +3,23 @@ CUDA_DIR = /usr/local/cuda
 CUDA_INCLUDE = -I$(CUDA_DIR)/include/
 CUDA_LIB = -L$(CUDA_DIR)/lib64/
 
+DEBUG = 0
+
 # compiler settings for .c files (CPU)
-CC = gcc
-CFLAGS = -Wall -Wextra -O3 -flto -malign-double -ffunction-sections -fdata-sections -Wl,--gc-sections $(CUDA_INCLUDE)
-CFLAGS_EXTRA_SIEVE = -funroll-all-loops
+CC ?= gcc
+CXX ?= g++
+CFLAGS = -Wall -Wextra $(CUDA_INCLUDE)
+
+ifeq ($(DEBUG), 1)
+  CFLAGS += -g -Og
+else
+  CFLAGS += -O3 -ffast-math -flto -ffunction-sections -fdata-sections
+  CFLAGS_EXTRA_SIEVE = -funroll-all-loops
+endif
 
 # compiler settings for .cu files (GPU)
 NVCC = nvcc
-NVCCFLAGS = $(CUDA_INCLUDE) --ptxas-options=-v -O3 -Wno-deprecated-gpu-targets
+NVCCFLAGS = $(CUDA_INCLUDE) --ptxas-options=-v -Wno-deprecated-gpu-targets
 
 # generate code for compute capabilities - see this table for supported
 # versions: https://en.wikipedia.org/wiki/CUDA#GPUs_supported
@@ -40,11 +49,15 @@ NVCCFLAGS += --generate-code arch=compute_90,code=sm_90 # Hopper GPUs
 NVCCFLAGS += --generate-code arch=compute_120,code=sm_120 # Blackwell GPUs
 
 # pass some options to the C host compiler
-NVCCFLAGS += --compiler-options=-Wall
+ifeq ($(DEBUG), 1)
+  NVCCFLAGS += -g -G -O1 --compiler-options="-Wall -Wextra -Og"
+else
+  NVCCFLAGS += -O3 --compiler-options="-Wall -Wextra -O3"
+endif
 
 # Linker
-LD = gcc
-LDFLAGS = -flto -fPIC -Wl,--gc-sections $(CUDA_LIB) -lcudart_static -lm -lstdc++
+LD = $(CXX)
+LDFLAGS = -flto -Wl,--gc-sections $(CUDA_LIB) -lcudart_static -lm -ldl -lrt -lpthread
 
 INSTALL = install
 

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -1,8 +1,24 @@
-CC = cl
-CFLAGS = /O2 /Oy /W2 /fp:fast /I"$(CUDA_PATH)\include" /I"$(CUDA_PATH)\include\cudart" /nologo
+DEBUG = 0
 
-NVCCFLAGS = -m64 -O3 --ptxas-options=-v -Wno-deprecated-gpu-targets
-CUFLAGS = -DWIN64 -Xcompiler "/EHsc /W3 /nologo /O2" $(NVCCFLAGS)
+CC = cl
+CFLAGS = /W4 /I"$(CUDA_PATH)\include" /I"$(CUDA_PATH)\include\cudart" /nologo
+
+ifeq ($(DEBUG), 1)
+  CFLAGS += /Od /Zi /RTC1
+else
+  CFLAGS += /O2 /GL /Gw /fp:fast
+endif
+
+NVCCFLAGS = -m64 --ptxas-options=-v -Wno-deprecated-gpu-targets
+CUFLAGS = -DWIN64 $(NVCCFLAGS)
+
+ifeq ($(DEBUG), 1)
+  NVCCFLAGS += -g -G -O1
+  CUFLAGS += -Xcompiler "/EHsc /W4 /nologo /Od /Zi"
+else
+  NVCCFLAGS += -O3 
+  CUFLAGS += -Xcompiler "/EHsc /W4 /nologo /O2 /Gw"
+endif
 
 ############################################################
 
@@ -29,7 +45,12 @@ NVCCFLAGS += --generate-code arch=compute_120,code=sm_120
 ############################################################
 
 LINK = link
-LFLAGS = /nologo
+
+ifeq ($(DEBUG), 1)
+  LFLAGS = /nologo
+else
+  LFLAGS = /nologo /LTCG /OPT:REF /OPT:ICF
+endif
 
 CSRC  = sieve.c timer.c parse.c read_config.c mfaktc.c checkpoint.c \
 	filelocking.c signal_handler.c output.c crc.c

--- a/src/output.c
+++ b/src/output.c
@@ -64,6 +64,9 @@ void print_help(char *string)
     printf("  --sleeptest            test sleep functions\n");
 }
 
+#ifdef __GNUC__
+__attribute__ ((format(printf, 2, 3)))
+#endif
 void logprintf(mystuff_t *mystuff, const char *fmt, ...)
 {
     va_list args;

--- a/src/output.h
+++ b/src/output.h
@@ -20,6 +20,9 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 extern "C" {
 #endif
 void print_help(char *string);
+#ifdef __GNUC__
+__attribute__ ((format(printf, 2, 3)))
+#endif
 void logprintf(mystuff_t *mystuff, const char *fmt, ...);
 
 void print_dez96(int96 a, char *buf);


### PR DESCRIPTION
This backports many of the same improvements that I made to PRPLL-NTT in https://github.com/gwoltman/gpuowl/pull/7 and https://github.com/gwoltman/gpuowl/pull/8.

* Changed the existing CI/build workflow into a separate CD workflow
  * Changed to build the Linux executables on CentOS 7 and Rocky Linux 8 instead of Ubuntu
    * For CUDA 12.5-13.2, this lowered the required glibc version from 2.39 to 2.28.
    * For CUDA 8, this lowered the required glibc version from 2.23 to 2.17.
* Added new CI workflow
  * Eliminates the need to build all 48 combinations of OS and CUDA version on each commit and PR
  * Added tests with Clang on Linux
  * Changed to build the debug executables, as the CD workflow now builds the release executables
  * Added ShellCheck job
* Updated Makefile
  * Added new `DEBUG` flag
  * Enabled `-ffast-math` for consistency with the Windows Makefile
  * Removed obsolete and redundant optimization flags
* Updated Windows Makefile
  * Enabled compiler warnings
  * Enabled Link Time Optimization (LTO) for consistency with the Linux Makefile
  * Removed obsolete and redundant optimization flags
* Enabled GCC/Clang to check the printf style arguments to the `logprintf()` function calls
* Minor improvements to Bash scripts
  * Fixed ShellCheck errors
  * Added error checking to the build helper script
  * Removed unnecessary quoting

Also see: https://github.com/primesearch/mfakto/pull/65