### PR TITLE
fix ShellCheck warnings in shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,5 +138,4 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Script
-      run: shopt -s globstar; shellcheck -o avoid-nullary-conditions,check-set-e-suppressed,deprecate-which,quote-safe-variables,require-double-brackets -s bash **/*.sh
-      continue-on-error: true
+      run: shopt -s globstar dotglob; shellcheck -o avoid-nullary-conditions,check-set-e-suppressed,deprecate-which,quote-safe-variables,require-double-brackets -s bash **/*.sh

--- a/.github/workflows/scripts/build_helper.sh
+++ b/.github/workflows/scripts/build_helper.sh
@@ -49,8 +49,10 @@ CUDA_VER_MAJOR=${CUDA_VERSION[0]}
 CUDA_VER_MINOR=${CUDA_VERSION[1]}
 echo -e "CUDA_VER_MAJOR=${CUDA_VER_MAJOR}\nCUDA_VER_MINOR=${CUDA_VER_MINOR}" > "$0.out"
 
-# Format CUDA_VER as single integer with both major and minor (inc. leading zero) versions.
-# Used for simple comparison of CUDA versions internally in this script.
+# Format CUDA_VER as single integer containing both the major and minor
+# versions; this includes leading zeroes. Used for simple comparison of CUDA
+# versions internally in this script (does not compare patch versions as
+# CUDA_VER does not expose this information).
 printf -v CUDA_VER %d%02d "${CUDA_VER_MAJOR}" "${CUDA_VER_MINOR}";
 
 # CUDA supports the --list-gpu-arch flag from 11.0.0 onwards.
@@ -120,11 +122,11 @@ MFAKTC_VER=$(LC_ALL=en_US.utf8 grep -iPo '#define[\s\t]+MFAKTC_VERSION[\s\t]+"v?
 GIT_TAG_VER=""
 
 if GIT_TAG_VER=$(git describe --tags 2>/dev/null); then
-    BASE_VER="$GIT_TAG_VER"
+  BASE_VER="$GIT_TAG_VER"
 else
-    SHA_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
-    BASE_VER="${MFAKTC_VER}-${SHA_SHORT}"
-    echo "Info: 'git describe --tags' failed; using ${BASE_VER} instead"
+  SHA_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
+  BASE_VER="${MFAKTC_VER}-${SHA_SHORT}"
+  echo "Info: 'git describe --tags' failed; using ${BASE_VER} instead"
 fi
 
 # We first try to use 'git describe' to obtain the mfaktc version.
@@ -138,9 +140,9 @@ fi
 # commit ID. This keeps BASE_NAME shorter for release builds while still
 # producing unique names for development builds.
 if [[ -n "$GIT_TAG_VER" && "$GIT_TAG_VER" != "$MFAKTC_VER"* ]]; then
-    SHA_SHORT=$(git rev-parse --short HEAD)
-    BASE_VER="${MFAKTC_VER}-${SHA_SHORT}"
-    echo "Warning: version in params.h does not match 'git describe --tags' output"
+  SHA_SHORT=$(git rev-parse --short HEAD)
+  BASE_VER="${MFAKTC_VER}-${SHA_SHORT}"
+  echo "Warning: version in params.h does not match 'git describe --tags' output"
 fi
 
 echo -e "COMPILER_VER=${COMPILER_VER}\nNVCC_VER=${NVCC_VER}\nOS_VER=${OS_VER}\nBASE_NAME=${BASE_NAME}" | tee -a "$0.out"

--- a/.github/workflows/scripts/build_helper.sh
+++ b/.github/workflows/scripts/build_helper.sh
@@ -28,7 +28,7 @@
 
 set -e -o pipefail
 
-if [[ -z "$1" ]]; then
+if [[ -z $1 ]]; then
   echo "Usage: $0 <CUDA version>" >&2
   exit 1
 fi
@@ -39,33 +39,33 @@ export GSORT='/usr/bin/sort'
 
 CUDA_VERSION_FULL=$(echo "$1" | head -n1 | grep -Eom1 -e '^[1-9]([0-9])?\.[0-9]{1,2}(\.[0-9]{1,3})?$')
 declare -a CUDA_VERSION
-IFS=" " read -r -a CUDA_VERSION <<< "$(echo "$CUDA_VERSION_FULL" | tr '.' ' ')"
-if [[ -z "${CUDA_VERSION[*]}" ]]; then
+IFS=" " read -r -a CUDA_VERSION <<<"$(echo "$CUDA_VERSION_FULL" | tr '.' ' ')"
+if [[ -z ${CUDA_VERSION[*]} ]]; then
   echo "Error: unexpected CUDA version $1" >&2
   exit 2
 fi
 
 CUDA_VER_MAJOR=${CUDA_VERSION[0]}
 CUDA_VER_MINOR=${CUDA_VERSION[1]}
-echo -e "CUDA_VER_MAJOR=${CUDA_VER_MAJOR}\nCUDA_VER_MINOR=${CUDA_VER_MINOR}" > "$0.out"
+echo -e "CUDA_VER_MAJOR=${CUDA_VER_MAJOR}\nCUDA_VER_MINOR=${CUDA_VER_MINOR}" >"$0.out"
 
 # Format CUDA_VER as single integer containing both the major and minor
 # versions; this includes leading zeroes. Used for simple comparison of CUDA
 # versions internally in this script (does not compare patch versions as
 # CUDA_VER does not expose this information).
-printf -v CUDA_VER %d%02d "${CUDA_VER_MAJOR}" "${CUDA_VER_MINOR}";
+printf -v CUDA_VER %d%02d "${CUDA_VER_MAJOR}" "${CUDA_VER_MINOR}"
 
 # CUDA supports the --list-gpu-arch flag from 11.0.0 onwards.
 # For older CUDA versions, use grep to parse the supported architectures from
 # the output of --help
-[[ "$CUDA_VER" -gt 1100 ]] && NVCC_OPTS='--list-gpu-arch' || NVCC_OPTS='--help'
+[[ $CUDA_VER -gt 1100 ]] && NVCC_OPTS='--list-gpu-arch' || NVCC_OPTS='--help'
 NVCC_REGEX='compute_[1-9][0-9]{1,2}'
 # CUDA 11.0.x is a special case. Its --help output lists compute_32 and higher,
 # but only compute capability 3.5 and later are supported.
-[[ "$CUDA_VER" -eq 1100 ]] && NVCC_REGEX='compute_(3[5-9]|[4-9][0-9])'
+[[ $CUDA_VER -eq 1100 ]] && NVCC_REGEX='compute_(3[5-9]|[4-9][0-9])'
 
 declare -a CC_LIST
-IFS=" " read -r -a CC_LIST <<< "$(nvcc "$NVCC_OPTS" | grep -Eoe "$NVCC_REGEX" | cut -d '_' -f2 | $GSORT -un | xargs)"
+IFS=" " read -r -a CC_LIST <<<"$(nvcc "$NVCC_OPTS" | grep -Eoe "$NVCC_REGEX" | cut -d '_' -f2 | $GSORT -un | xargs)"
 if [[ ${#CC_LIST[*]} -eq 0 ]]; then
   echo "Error: could not parse list of supported compute capabilities" >&2
   exit 3
@@ -73,10 +73,10 @@ elif [[ ${#CC_LIST[*]} -lt 3 ]]; then
   echo "Warning: less than three (3) supported compute capabilities" >&2
 fi
 
-CC_MIN="${CC_LIST[0]:0:(-1)}.${CC_LIST[0]:(-1)}"
-CC_MAX="${CC_LIST[-1]:0:(-1)}.${CC_LIST[-1]:(-1)}"
+CC_MIN="${CC_LIST[0]:0:-1}.${CC_LIST[0]: -1}"
+CC_MAX="${CC_LIST[-1]:0:-1}.${CC_LIST[-1]: -1}"
 echo "All supported CCs: ${CC_LIST[*]}, CC_MIN=${CC_MIN}, CC_MAX=${CC_MAX}"
-echo -e "CC_LIST=\"${CC_LIST[*]}\"\nCC_MIN=${CC_MIN}\nCC_MAX=${CC_MAX}" >> "$0.out"
+echo -e "CC_LIST=\"${CC_LIST[*]}\"\nCC_MIN=${CC_MIN}\nCC_MAX=${CC_MAX}" >>"$0.out"
 
 echo 'Removing NVCCFLAGS strings with "arch=..." entries from makefiles and populating them with discovered supported values.'
 sed -i '/^NVCCFLAGS += --generate-code arch=compute.*/d' src/Makefile.win src/Makefile
@@ -84,7 +84,7 @@ for CC in "${CC_LIST[@]}"; do
   sed -i "/^NVCCFLAGS = .*\$/a NVCCFLAGS += --generate-code arch=compute_${CC},code=sm_${CC}" src/Makefile src/Makefile.win
 done
 
-if [[ "$CUDA_VER" -ge 1100 ]]; then
+if [[ $CUDA_VER -ge 1100 ]]; then
   echo 'Adding NVCCFLAGS to allow unsupported MSVC versions...'
   sed -i '/^NVCCFLAGS = .*/a NVCCFLAGS += -allow-unsupported-compiler -D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH' src/Makefile.win
 fi
@@ -139,7 +139,7 @@ fi
 # others, this also includes the number of commits since the tag plus the
 # commit ID. This keeps BASE_NAME shorter for release builds while still
 # producing unique names for development builds.
-if [[ -n "$GIT_TAG_VER" && "$GIT_TAG_VER" != "$MFAKTC_VER"* ]]; then
+if [[ -n $GIT_TAG_VER && $GIT_TAG_VER != "$MFAKTC_VER"* ]]; then
   SHA_SHORT=$(git rev-parse --short HEAD)
   BASE_VER="${MFAKTC_VER}-${SHA_SHORT}"
   echo "Warning: version in params.h does not match 'git describe --tags' output"

--- a/contrib/start-mfaktc.sh
+++ b/contrib/start-mfaktc.sh
@@ -78,22 +78,22 @@ run_on_device() {
             echo "error: $APP_SETTINGS not found in root folder" >&2
             exit 1
         else
-            ln -s ../$APP_SETTINGS .
+            ln -s ../"$APP_SETTINGS" .
         fi
     fi
 
-    ln -s ../$APP . && app_created=1
+    ln -s ../"$APP" . && app_created=1
 
     cleanup() {
-        [[ -n "$app_created" ]] && rm -f $APP
+        [[ -n "$app_created" ]] && rm -f "$APP"
 
         # don't delete mfaktc.ini unless it's a symbolic link
-        [[ -L $APP_SETTINGS ]] && rm $APP_SETTINGS
+        [[ -L $APP_SETTINGS ]] && rm "$APP_SETTINGS"
     }
     trap 'cleanup' EXIT
 
     # run mfaktc on specified device
-    ./$APP -d "$1"
+    ./"$APP" -d "$1"
 }
 
 # mfaktc executable must be present
@@ -112,7 +112,7 @@ if [[ $# -eq 0 ]]; then
     fi
 
     # run mfaktc on default device
-    exec ./$APP
+    exec ./"$APP"
 else
     run_on_device "$1"
 fi

--- a/contrib/start-mfaktc.sh
+++ b/contrib/start-mfaktc.sh
@@ -85,7 +85,7 @@ run_on_device() {
     ln -s ../"$APP" . && app_created=1
 
     cleanup() {
-        [[ -n "$app_created" ]] && rm -f "$APP"
+        [[ -n $app_created ]] && rm -f "$APP"
 
         # don't delete mfaktc.ini unless it's a symbolic link
         [[ -L $APP_SETTINGS ]] && rm "$APP_SETTINGS"

--- a/src/create_dependencies.sh
+++ b/src/create_dependencies.sh
@@ -39,14 +39,27 @@ cpp -D CUDART_VERSION=13000 -include selftest-data-mersenne.c -include \
     selftest-data-wagstaff.c -MM mfaktc.c
 echo
 
-for FILE in checkpoint.c output.c parse.c read_config.c sieve.c \
-            signal_handler.c timer.c tf_96bit.cu tf_barrett96.cu \
-            tf_barrett96_gs.cu gpusieve.cu cuda_utils.cu crc.c
-do
-  cpp -D CUDART_VERSION=13000 -MM ${FILE}
+FILES=(
+  checkpoint.c
+  output.c
+  parse.c
+  read_config.c
+  sieve.c
+  signal_handler.c
+  timer.c
+  tf_96bit.cu
+  tf_barrett96.cu
+  tf_barrett96_gs.cu
+  gpusieve.cu
+  cuda_utils.cu
+  crc.c
+)
+
+for FILE in "${FILES[@]}"; do
+  cpp -D CUDART_VERSION=13000 -MM "$FILE"
   echo
 done
 
 # special case for 75-bit kernels
 cpp -D CUDART_VERSION=13000 -MM tf_96bit.cu -MT tf_75bit.o
-) | sed s@\.o:@\.${OBJ}:@
+) | sed s@\.o:@\."${OBJ}":@

--- a/src/create_dependencies.sh
+++ b/src/create_dependencies.sh
@@ -35,31 +35,31 @@ esac
 # Mersenne or Wagstaff numbers in params.h. For simplicity's sake, we just add
 # both files.
 (
-cpp -D CUDART_VERSION=13000 -include selftest-data-mersenne.c -include \
+  cpp -D CUDART_VERSION=13000 -include selftest-data-mersenne.c -include \
     selftest-data-wagstaff.c -MM mfaktc.c
-echo
-
-FILES=(
-  checkpoint.c
-  output.c
-  parse.c
-  read_config.c
-  sieve.c
-  signal_handler.c
-  timer.c
-  tf_96bit.cu
-  tf_barrett96.cu
-  tf_barrett96_gs.cu
-  gpusieve.cu
-  cuda_utils.cu
-  crc.c
-)
-
-for FILE in "${FILES[@]}"; do
-  cpp -D CUDART_VERSION=13000 -MM "$FILE"
   echo
-done
 
-# special case for 75-bit kernels
-cpp -D CUDART_VERSION=13000 -MM tf_96bit.cu -MT tf_75bit.o
-) | sed s@\.o:@\."${OBJ}":@
+  FILES=(
+    checkpoint.c
+    output.c
+    parse.c
+    read_config.c
+    sieve.c
+    signal_handler.c
+    timer.c
+    tf_96bit.cu
+    tf_barrett96.cu
+    tf_barrett96_gs.cu
+    gpusieve.cu
+    cuda_utils.cu
+    crc.c
+  )
+
+  for FILE in "${FILES[@]}"; do
+    cpp -D CUDART_VERSION=13000 -MM "$FILE"
+    echo
+  done
+
+  # special case for 75-bit kernels
+  cpp -D CUDART_VERSION=13000 -MM tf_96bit.cu -MT tf_75bit.o
+) | sed "s|\.o:|\.${OBJ}:|"


### PR DESCRIPTION
Fixed the ShellCheck warnings in the shell scripts.

Additional changes:
* converted the list of source files in `create_dependencies.sh` to an array as the original code would break some parsers
* made the code formatting more consistent