### PR TITLE
fix CodeQL warnings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Install Git
       run: apt-get update && apt-get install -y git
 
+    - name: Configure Git safe directory
+      run: git config --global --add safe.directory /__w/mfaktc/mfaktc
+
     - name: Checkout repository
       uses: actions/checkout@v7
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,8 +29,11 @@ jobs:
       matrix:
         include:
         - language: c-cpp
-          build-mode: autobuild
+          build-mode: none
     steps:
+    - name: Install Git
+      run: apt-get update && apt-get install -y git
+
     - name: Checkout repository
       uses: actions/checkout@v7
 


### PR DESCRIPTION
This PR resolves two warnings related to the CodeQL code analyer.

We should ideally set the build mode to `manual` for best results, but that might require significant changes to the workflow file.